### PR TITLE
feat: add koto instrument

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -68,6 +68,7 @@
         <div id="bassHost" class="hidden"></div>
         <div id="fluteHost" class="hidden"></div>
         <div id="recorderHost" class="hidden"></div>
+        <div id="kotoHost" class="hidden"></div>
 
         <div class="flex items-center gap-2 pt-1">
           <span id="badgeId" class="px-2 py-0.5 rounded-full text-xs font-semibold border bg-slate-700/40 text-slate-300 border-slate-600">Selection: —</span>
@@ -136,6 +137,7 @@ const INSTRUMENTS = [
   "Bass",
   "Flute",
   "Recorder",
+  "Koto",
   "Oud",
   "Ney",
   "Hammond Organ"
@@ -246,6 +248,7 @@ let _synth=null; let _started=false; const ENV={
   Bass:{a:.005,d:.25,s:.4,r:.8,osc:'square'},
   Flute:{a:.04,d:.12,s:.8,r:.5,osc:'sine'},
   Recorder:{a:.03,d:.15,s:.7,r:.4,osc:'sine'},
+  Koto:{a:.002,d:.3,s:0,r:1.6,osc:'triangle'},
   Oud:{a:.002,d:.35,s:0,r:1.8,osc:'triangle'},
   Ney:{a:.08,d:.12,s:.7,r:.5,osc:'sine'},
   'Hammond Organ':{a:.03,d:.2,s:.8,r:.7,osc:'square'}
@@ -266,7 +269,7 @@ async function copyBytesToClipboard(bytes){ const status=document.getElementById
 
 // ========================= UI STATE =========================
 const $ = (sel)=>document.querySelector(sel);
-const pianoHost = $('#pianoHost'); const guitarHost = $('#guitarHost'); const bassHost = $('#bassHost'); const fluteHost = $('#fluteHost'); const recorderHost = $('#recorderHost');
+const pianoHost = $('#pianoHost'); const guitarHost = $('#guitarHost'); const bassHost = $('#bassHost'); const fluteHost = $('#fluteHost'); const recorderHost = $('#recorderHost'); const kotoHost = $('#kotoHost');
 const selKey = $('#selKey'); const selQuality = $('#selQuality'); const selMode = $('#selMode'); const selInstr = $('#selInstr'); const selSystem = $('#selSystem');
 const badgeRoot = $('#badgeRoot'); const badgeChordNotes = $('#badgeChordNotes'); const badgeScaleNotes = $('#badgeScaleNotes');
 const badgeId = $('#badgeId'); const badgeSelNotes = $('#badgeSelNotes');
@@ -333,11 +336,13 @@ function renderHighlights(){ const {pcset, rootPc} = computeSelected(); // visua
 }
 
 // ========================= FRETBOARDS =========================
-const GUITAR_STD=[40,45,50,55,59,64]; const BASS_STD=[28,33,38,43];
+const GUITAR_STD=[40,45,50,55,59,64]; const BASS_STD=[28,33,38,43]; const KOTO_TUNING=[60,62,64,67,69,72,74,76,79,81,84,86,88];
 function buildFretboard(host, tuning, title){ host.innerHTML=''; const outer=document.createElement('div'); outer.className='w-full'; const titleEl=document.createElement('div'); titleEl.className='text-sm text-slate-300 mb-2'; titleEl.textContent = `${title} • Tuning: ` + tuning.map(m=> pcName(mod(m,OCTAVE))+(Math.floor(m/OCTAVE)-1)).join(' '); outer.appendChild(titleEl); const box=document.createElement('div'); box.className='bg-slate-900 rounded-xl border border-slate-700 p-3'; const grid=document.createElement('div'); grid.className='grid'; const frets=13; grid.style.gridTemplateColumns = `repeat(${frets+1}, minmax(0,1fr))`; box.appendChild(grid); // header row
   grid.appendChild(document.createElement('div')); for(let f=0; f<frets; f++){ const d=document.createElement('div'); d.className='text-center text-[10px] text-slate-400'; d.textContent=String(f); grid.appendChild(d); }
   const {pcset, rootPc} = computeSelected(); const strings=tuning.length; for(let s=0; s<strings; s++){ const stringIndex=strings-1-s; const openMidi=tuning[stringIndex]; const lab=document.createElement('div'); lab.className='text-right pr-2 text-[11px] text-slate-400'; lab.textContent=pcName(mod(openMidi,OCTAVE)); grid.appendChild(lab); for(let f=0; f<frets; f++){ const midi=openMidi+f; const pc=mod(midi,OCTAVE); const cell=document.createElement('div'); cell.className='relative h-10 border border-slate-700/70'; if(pcset.has(pc)){ const dot=document.createElement('div'); dot.className = 'absolute inset-1 rounded-full flex items-center justify-center text-[10px] font-semibold '+ (rootPc===pc? 'bg-rose-500/80 text-white':'bg-emerald-400/80 text-black'); dot.title = `${pcName(pc)} @ string ${stringIndex+1}, fret ${f}`; dot.textContent = (rootPc===pc? 'R': pcName(pc)); cell.appendChild(dot); } grid.appendChild(cell); } }
   outer.appendChild(box); const note=document.createElement('div'); note.className='mt-2 text-center text-xs text-slate-400'; note.textContent='Colored dots = playable notes on that string/fret. Red = root.'; outer.appendChild(note); host.appendChild(outer); }
+
+function buildKotoBoard(){ kotoHost.innerHTML=''; const outer=document.createElement('div'); outer.className='w-full'; const titleEl=document.createElement('div'); titleEl.className='text-sm text-slate-300 mb-2'; titleEl.textContent='Koto • Tuning: '+KOTO_TUNING.map(m=> pcName(mod(m,OCTAVE))+(Math.floor(m/OCTAVE)-1)).join(' '); outer.appendChild(titleEl); const board=document.createElement('div'); board.className='bg-slate-900 rounded-xl border border-slate-700 p-3'; const {pcset, rootPc} = computeSelected(); KOTO_TUNING.forEach((m)=>{ const pc=mod(m,OCTAVE); const row=document.createElement('div'); row.className='relative h-5 my-1 flex items-center'; const line=document.createElement('div'); line.className='w-full h-0.5'; line.style.backgroundColor = pcset.has(pc)? (rootPc===pc? '#f43f5e':'#4ade80') : '#cbd5e1'; row.appendChild(line); const lab=document.createElement('div'); lab.className='absolute -left-2 -translate-x-full text-xs text-slate-400'; lab.textContent=pcName(pc)+(Math.floor(m/OCTAVE)-1); row.appendChild(lab); if(pcset.has(pc)){ const dot=document.createElement('div'); dot.className='absolute right-0 top-1/2 -translate-y-1/2 px-1 text-[10px] font-semibold rounded '+(rootPc===pc? 'bg-rose-500/80 text-white':'bg-emerald-400/80 text-black'); dot.textContent = rootPc===pc? 'R': pcName(pc); row.appendChild(dot); } board.appendChild(row); }); outer.appendChild(board); kotoHost.appendChild(outer); }
 
 // ========================= FLUTE CHART =========================
 const FLUTE_FINGERINGS = {
@@ -470,15 +475,18 @@ function refreshInstruments(){
   const isBass = selInstr.value.startsWith('Bass');
   const isFlute = selInstr.value.startsWith('Flute');
   const isRecorder = selInstr.value.startsWith('Recorder');
+  const isKoto = selInstr.value.startsWith('Koto');
   guitarHost.classList.toggle('hidden', !isGuitar);
   bassHost.classList.toggle('hidden', !isBass);
   fluteHost.classList.toggle('hidden', !isFlute);
   recorderHost.classList.toggle('hidden', !isRecorder);
+  kotoHost.classList.toggle('hidden', !isKoto);
   if(isFlute) buildFluteChart();
   if(isRecorder) buildRecorderChart();
+  if(isKoto) buildKotoBoard();
   btnPlayStrum.classList.toggle('hidden', !isGuitar);
 }
-function updateAll(){ renderHighlights(); updateBadges(); if(!guitarHost.classList.contains('hidden')) buildFretboard(guitarHost, GUITAR_STD,'Guitar (12 frets)'); if(!bassHost.classList.contains('hidden')) buildFretboard(bassHost, BASS_STD,'Bass (12 frets)'); if(!fluteHost.classList.contains('hidden')) buildFluteChart(); if(!recorderHost.classList.contains('hidden')) buildRecorderChart(); }
+function updateAll(){ renderHighlights(); updateBadges(); if(!guitarHost.classList.contains('hidden')) buildFretboard(guitarHost, GUITAR_STD,'Guitar (12 frets)'); if(!bassHost.classList.contains('hidden')) buildFretboard(bassHost, BASS_STD,'Bass (12 frets)'); if(!fluteHost.classList.contains('hidden')) buildFluteChart(); if(!recorderHost.classList.contains('hidden')) buildRecorderChart(); if(!kotoHost.classList.contains('hidden')) buildKotoBoard(); }
 
 // Build UI
 buildPiano(); refreshInstruments(); updateAll(); runTests();


### PR DESCRIPTION
## Summary
- add Koto to instrument list and synth envelope
- render new 13-string koto board with procedural shapes
- refresh instrument logic to show Koto board when selected

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf75930ac832c815e03d291a66b67