### PR TITLE
Add violin instrument with tuning and visualization

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -66,6 +66,7 @@
         <div id="pianoHost"></div>
         <div id="guitarHost" class="hidden"></div>
         <div id="bassHost" class="hidden"></div>
+        <div id="violinHost" class="hidden"></div>
         <div id="fluteHost" class="hidden"></div>
         <div id="recorderHost" class="hidden"></div>
         <div id="kotoHost" class="hidden"></div>
@@ -136,6 +137,7 @@ const INSTRUMENTS = [
   "Piano",
   "Guitar",
   "Bass",
+  "Violin",
   "Flute",
   "Recorder",
   "Koto",
@@ -247,6 +249,7 @@ let _synth=null; let _started=false; const ENV={
   Piano:{a:.002,d:.3,s:.3,r:1.2,osc:'triangle'},
   Guitar:{a:.002,d:.25,s:0,r:1.5,osc:'sawtooth'},
   Bass:{a:.005,d:.25,s:.4,r:.8,osc:'square'},
+  Violin:{a:.01,d:.12,s:.7,r:.6,osc:'sawtooth'},
   Flute:{a:.04,d:.12,s:.8,r:.5,osc:'sine'},
   Recorder:{a:.03,d:.15,s:.7,r:.4,osc:'sine'},
   Koto:{a:.002,d:.3,s:0,r:1.6,osc:'triangle'},
@@ -270,7 +273,7 @@ async function copyBytesToClipboard(bytes){ const status=document.getElementById
 
 // ========================= UI STATE =========================
 const $ = (sel)=>document.querySelector(sel);
-const pianoHost = $('#pianoHost'); const guitarHost = $('#guitarHost'); const bassHost = $('#bassHost'); const fluteHost = $('#fluteHost'); const recorderHost = $('#recorderHost'); const kotoHost = $('#kotoHost'); const neyHost = $('#neyHost');
+const pianoHost = $('#pianoHost'); const guitarHost = $('#guitarHost'); const bassHost = $('#bassHost'); const violinHost = $('#violinHost'); const fluteHost = $('#fluteHost'); const recorderHost = $('#recorderHost'); const kotoHost = $('#kotoHost'); const neyHost = $('#neyHost');
 const selKey = $('#selKey'); const selQuality = $('#selQuality'); const selMode = $('#selMode'); const selInstr = $('#selInstr'); const selSystem = $('#selSystem');
 const badgeRoot = $('#badgeRoot'); const badgeChordNotes = $('#badgeChordNotes'); const badgeScaleNotes = $('#badgeScaleNotes');
 const badgeId = $('#badgeId'); const badgeSelNotes = $('#badgeSelNotes');
@@ -337,7 +340,7 @@ function renderHighlights(){ const {pcset, rootPc} = computeSelected(); // visua
 }
 
 // ========================= FRETBOARDS =========================
-const GUITAR_STD=[40,45,50,55,59,64]; const BASS_STD=[28,33,38,43]; const KOTO_TUNING=[60,62,64,67,69,72,74,76,79,81,84,86,88];
+const GUITAR_STD=[40,45,50,55,59,64]; const BASS_STD=[28,33,38,43]; const VIOLIN_TUNING=[55,62,69,76]; const KOTO_TUNING=[60,62,64,67,69,72,74,76,79,81,84,86,88];
 function buildFretboard(host, tuning, title){ host.innerHTML=''; const outer=document.createElement('div'); outer.className='w-full'; const titleEl=document.createElement('div'); titleEl.className='text-sm text-slate-300 mb-2'; titleEl.textContent = `${title} • Tuning: ` + tuning.map(m=> pcName(mod(m,OCTAVE))+(Math.floor(m/OCTAVE)-1)).join(' '); outer.appendChild(titleEl); const box=document.createElement('div'); box.className='bg-slate-900 rounded-xl border border-slate-700 p-3'; const grid=document.createElement('div'); grid.className='grid'; const frets=13; grid.style.gridTemplateColumns = `repeat(${frets+1}, minmax(0,1fr))`; box.appendChild(grid); // header row
   grid.appendChild(document.createElement('div')); for(let f=0; f<frets; f++){ const d=document.createElement('div'); d.className='text-center text-[10px] text-slate-400'; d.textContent=String(f); grid.appendChild(d); }
   const {pcset, rootPc} = computeSelected(); const strings=tuning.length; for(let s=0; s<strings; s++){ const stringIndex=strings-1-s; const openMidi=tuning[stringIndex]; const lab=document.createElement('div'); lab.className='text-right pr-2 text-[11px] text-slate-400'; lab.textContent=pcName(mod(openMidi,OCTAVE)); grid.appendChild(lab); for(let f=0; f<frets; f++){ const midi=openMidi+f; const pc=mod(midi,OCTAVE); const cell=document.createElement('div'); cell.className='relative h-10 border border-slate-700/70'; if(pcset.has(pc)){ const dot=document.createElement('div'); dot.className = 'absolute inset-1 rounded-full flex items-center justify-center text-[10px] font-semibold '+ (rootPc===pc? 'bg-rose-500/80 text-white':'bg-emerald-400/80 text-black'); dot.title = `${pcName(pc)} @ string ${stringIndex+1}, fret ${f}`; dot.textContent = (rootPc===pc? 'R': pcName(pc)); cell.appendChild(dot); } grid.appendChild(cell); } }
@@ -518,23 +521,26 @@ function runTests(){
 function refreshInstruments(){
   const isGuitar = selInstr.value.startsWith('Guitar') || selInstr.value.startsWith('Oud');
   const isBass = selInstr.value.startsWith('Bass');
+  const isViolin = selInstr.value.startsWith('Violin');
   const isFlute = selInstr.value.startsWith('Flute');
   const isRecorder = selInstr.value.startsWith('Recorder');
   const isKoto = selInstr.value.startsWith('Koto');
   const isNey = selInstr.value.startsWith('Ney');
   guitarHost.classList.toggle('hidden', !isGuitar);
   bassHost.classList.toggle('hidden', !isBass);
+  violinHost.classList.toggle('hidden', !isViolin);
   fluteHost.classList.toggle('hidden', !isFlute);
   recorderHost.classList.toggle('hidden', !isRecorder);
   kotoHost.classList.toggle('hidden', !isKoto);
   neyHost.classList.toggle('hidden', !isNey);
+  if(isViolin) buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)');
   if(isFlute) buildFluteChart();
   if(isRecorder) buildRecorderChart();
   if(isKoto) buildKotoBoard();
   if(isNey) buildNeyChart();
   btnPlayStrum.classList.toggle('hidden', !isGuitar);
 }
-function updateAll(){ renderHighlights(); updateBadges(); if(!guitarHost.classList.contains('hidden')) buildFretboard(guitarHost, GUITAR_STD,'Guitar (12 frets)'); if(!bassHost.classList.contains('hidden')) buildFretboard(bassHost, BASS_STD,'Bass (12 frets)'); if(!fluteHost.classList.contains('hidden')) buildFluteChart(); if(!recorderHost.classList.contains('hidden')) buildRecorderChart(); if(!kotoHost.classList.contains('hidden')) buildKotoBoard(); if(!neyHost.classList.contains('hidden')) buildNeyChart(); }
+function updateAll(){ renderHighlights(); updateBadges(); if(!guitarHost.classList.contains('hidden')) buildFretboard(guitarHost, GUITAR_STD,'Guitar (12 frets)'); if(!bassHost.classList.contains('hidden')) buildFretboard(bassHost, BASS_STD,'Bass (12 frets)'); if(!violinHost.classList.contains('hidden')) buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)'); if(!fluteHost.classList.contains('hidden')) buildFluteChart(); if(!recorderHost.classList.contains('hidden')) buildRecorderChart(); if(!kotoHost.classList.contains('hidden')) buildKotoBoard(); if(!neyHost.classList.contains('hidden')) buildNeyChart(); }
 
 // Build UI
 buildPiano(); refreshInstruments(); updateAll(); runTests();


### PR DESCRIPTION
## Summary
- add Violin option and audio envelope settings
- provide violin tuning and board rendering using existing fretboard builder
- handle violin host in instrument refresh and update logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf994116c832c9ae72275beae14a2