### PR TITLE
Ensure woodwind charts rebuild whenever active

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -545,14 +545,31 @@ function refreshInstruments(){
   recorderHost.classList.toggle('hidden', !isRecorder);
   kotoHost.classList.toggle('hidden', !isKoto);
   neyHost.classList.toggle('hidden', !isNey);
-  if(isViolin) buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)');
-  if(isFlute) buildFluteChart();
-  if(isRecorder) buildRecorderChart();
-  if(isKoto) buildKotoBoard();
-  if(isNey) buildNeyChart();
+  if(!violinHost.classList.contains('hidden')) buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)');
+  if(!fluteHost.classList.contains('hidden')) buildFluteChart();
+  if(!recorderHost.classList.contains('hidden')) buildRecorderChart();
+  if(!kotoHost.classList.contains('hidden')) buildKotoBoard();
+  if(!neyHost.classList.contains('hidden')) buildNeyChart();
   btnPlayStrum.classList.toggle('hidden', !isGuitar);
 }
-function updateAll(){ renderHighlights(); updateBadges(); if(!guitarHost.classList.contains('hidden')) buildFretboard(guitarHost, GUITAR_STD,'Guitar (12 frets)'); if(!bassHost.classList.contains('hidden')) buildFretboard(bassHost, BASS_STD,'Bass (12 frets)'); if(!violinHost.classList.contains('hidden')) buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)'); if(!fluteHost.classList.contains('hidden')) buildFluteChart(); if(!recorderHost.classList.contains('hidden')) buildRecorderChart(); if(!kotoHost.classList.contains('hidden')) buildKotoBoard(); if(!neyHost.classList.contains('hidden')) buildNeyChart(); }
+function updateAll(){
+  renderHighlights();
+  updateBadges();
+  if(!guitarHost.classList.contains('hidden'))
+    buildFretboard(guitarHost, GUITAR_STD,'Guitar (12 frets)');
+  if(!bassHost.classList.contains('hidden'))
+    buildFretboard(bassHost, BASS_STD,'Bass (12 frets)');
+  if(!violinHost.classList.contains('hidden'))
+    buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)');
+  if(!fluteHost.classList.contains('hidden'))
+    buildFluteChart();
+  if(!recorderHost.classList.contains('hidden'))
+    buildRecorderChart();
+  if(!kotoHost.classList.contains('hidden'))
+    buildKotoBoard();
+  if(!neyHost.classList.contains('hidden'))
+    buildNeyChart();
+}
 
 // Build UI
 buildPiano(); refreshInstruments(); updateAll(); runTests();


### PR DESCRIPTION
## Summary
- Always rebuild flute and recorder diagrams whenever their hosts are visible.
- Refactor `updateAll` for readability and consistent host checks.

## Testing
- `node - <<'NODE'
const fs=require('fs');
const {JSDOM}=require('jsdom');
let html=fs.readFileSync('chord_scale_library_html_tailwind_tone.html','utf8');
html=html.replace(/<script src="https:\/\/cdn\.tailwindcss\.com"><\/script>/,'').replace(/<script src="https:\/\/unpkg\.com\/tone[^>]+><\/script>/,'');
const dom=new JSDOM(html,{runScripts:"dangerously"});
const {window}=dom;
window.selInstr.value='Flute';
window.instrument='Flute';
window.refreshInstruments();
window.updateAll();
let cx1=window.document.querySelector('#fluteHost svg circle').getAttribute('cx');
console.log('flute initial cx:',cx1);
window.document.getElementById('fluteFlip').click();
let cx2=window.document.querySelector('#fluteHost svg circle').getAttribute('cx');
console.log('flute flipped cx:',cx2);
window.selInstr.value='Recorder';
window.instrument='Recorder';
window.refreshInstruments();
window.updateAll();
let cyRec=window.document.querySelector('#recorderHost svg circle').getAttribute('cy');
console.log('recorder cy:',cyRec);
window.selInstr.value='Flute';
window.instrument='Flute';
window.refreshInstruments();
window.updateAll();
let cx3=window.document.querySelector('#fluteHost svg circle').getAttribute('cx');
console.log('flute after switch back cx:',cx3);
window.selKey.value='D';
window.keyRoot='D';
window.updateAll();
let cx4=window.document.querySelector('#fluteHost svg circle').getAttribute('cx');
console.log('flute after key change cx:',cx4);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68abfb637170832c95ce8a0c9cc614d6