### PR TITLE
Update README for final Chord & Scale Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# Chord & Scale Library Prototype
+# Chord & Scale Library
 
-This repository contains a single HTML prototype that demonstrates an interactive chord and scale explorer. The page is built entirely with client-side code and relies on [Tailwind CSS](https://tailwindcss.com/) for styling and [Tone.js](https://tonejs.github.io/) for audio playback.
+This repository contains a single HTML page providing a fully functional interactive chord and scale explorer. The page is built entirely with client-side code and relies on [Tailwind CSS](https://tailwindcss.com/) for styling and [Tone.js](https://tonejs.github.io/) for audio playback.
 
 ## Features
 
 - **Mode and chord exploration** – switch between chord and scale modes, choose a key, and browse available musical systems.
-- **Western and Maqam systems** – select from Western modes or quarter‑tone maqam modes with microtonal intervals.
-- **Instrument playback** – preview chords or scales using built‑in synth sounds (piano, guitar, bass, flute) powered by Tone.js.
+- **Western and Maqam systems** – select from Western modes or quarter-tone maqam modes with microtonal intervals.
+- **Instrument playback** – preview chords or scales using built-in synth sounds (piano, guitar, bass, flute) powered by Tone.js.
 - **MIDI export** – generate and copy simple MIDI data for further use in a DAW.
 
 ## Usage and Contribution
 
 Open the `chord_scale_library_html_tailwind_tone.html` file in a modern browser to experiment with chords, scales, and microtonal modes. This framework is released for anyone to use, modify, and expand without restriction. Contributions and new ideas are welcome.
-


### PR DESCRIPTION
## Summary
- remove "Prototype" from the Chord & Scale Library heading
- describe the HTML page as the final interactive release

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68ac02b134dc832c9a43e14c0562748c