### PR TITLE
Remove prototype labels from HTML library page

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Chord & Scale Library — Prototype (HTML)</title>
+  <title>Chord & Scale Library</title>
   <!-- Tailwind (CDN) for the same look/feel as your TSX version -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Tone.js for audio playback -->
@@ -12,7 +12,7 @@
 <body class="min-h-screen w-full bg-slate-950 text-slate-100">
   <div class="max-w-6xl mx-auto p-6">
     <header class="mb-6 flex items-center justify-between">
-      <h1 class="text-2xl md:text-3xl font-bold">Chord & Scale Library — Prototype (HTML)</h1>
+      <h1 class="text-2xl md:text-3xl font-bold">Chord & Scale Library</h1>
       <div class="text-xs text-slate-400">Audio starts on first click • Tone.js</div>
     </header>
 
@@ -118,7 +118,7 @@
       <div id="tests" class="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm"></div>
     </section>
 
-    <footer class="mt-10 text-center text-xs text-slate-500">© 2025 — Interactive Chord & Scale Library (HTML Prototype)</footer>
+      <footer class="mt-10 text-center text-xs text-slate-500">© 2025 — Interactive Chord & Scale Library</footer>
   </div>
 
 <script>


### PR DESCRIPTION
## Summary
- drop "Prototype (HTML)" from document title and main heading
- update footer to remove prototype wording

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac02b94978832c90a63f9473b1d85d