### PR TITLE
Add sustain snap toggle and held note durations

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -78,7 +78,7 @@
           <span id="badgeId" class="px-2 py-0.5 rounded-full text-xs font-semibold border bg-slate-700/40 text-slate-300 border-slate-600">Selection: —</span>
           <span id="badgeSelNotes" class="px-2 py-0.5 rounded-full text-xs font-semibold border bg-slate-700/40 text-slate-300 border-slate-600">Notes: —</span>
           <button id="btnClearSel" class="px-2 py-1 text-xs font-semibold rounded-lg border bg-slate-700/40 text-slate-300 border-slate-600 hover:bg-slate-700/60">Clear Selection</button>
-          <span class="text-xs text-slate-400">Tip: click keys to pluck • <span class="font-semibold">Shift+click</span> toggles selection</span>
+          <span class="text-xs text-slate-400">Tip: hold keys to play • <span class="font-semibold">Shift+click</span> toggles selection</span>
         </div>
       </div>
     </section>
@@ -100,6 +100,10 @@
         <div id="listenSel" class="mt-4 flex flex-wrap gap-3 items-center">
           <button id="btnPlaySelChord" disabled class="px-4 py-2 rounded-xl bg-teal-600 hover:bg-teal-500 text-white font-semibold disabled:opacity-50 disabled:cursor-not-allowed">Play Selection (chord)</button>
           <button id="btnPlaySelArp" disabled class="px-4 py-2 rounded-xl bg-cyan-600 hover:bg-cyan-500 text-white font-semibold disabled:opacity-50 disabled:cursor-not-allowed">Play Selection (arp)</button>
+        </div>
+        <div class="mt-4 flex items-center gap-2">
+          <input id="heldSustainSnap" type="checkbox" class="h-4 w-4" checked>
+          <label for="heldSustainSnap" class="text-sm text-slate-300">Snap held note sustain to 1/16 note</label>
         </div>
       </div>
     </section>
@@ -274,7 +278,7 @@ function midiToFreq(m){ return 440 * Math.pow(2, (m - 69) / 12); }
 // Plays MIDI notes using the synth. Notes are sequenced by default;
 // use `asChord` to trigger them simultaneously or `strum` for a quick
 // guitar-style roll.
-async function playMidiNotes(list, {instrument='Piano', tempo=110, asChord=false, strum=false}={}){
+async function playMidiNotes(list, {instrument='Piano', tempo=110, asChord=false, strum=false, noteDur}={}){
   await ensureTone(instrument);
   const beat=60/tempo;
   const now=Tone.now();
@@ -289,6 +293,10 @@ async function playMidiNotes(list, {instrument='Piano', tempo=110, asChord=false
     });
     return;
   }
+  if(noteDur!==undefined && list.length===1){
+    _synth.triggerAttackRelease(midiToFreq(list[0]), noteDur, now);
+    return;
+  }
   const seq=list;
   seq.forEach((m,i)=>{
     const t=now + i*(beat*0.6);
@@ -296,7 +304,6 @@ async function playMidiNotes(list, {instrument='Piano', tempo=110, asChord=false
   });
 }
 // Limitation: only oscillator-based synth; sample instruments would require per-voice pitch bend.
-async function pluck(m, instrument, tempo){ await ensureTone(instrument); _synth.triggerAttackRelease(midiToFreq(m), 0.25); }
 
 // ========================= MIDI (SMF Type 0) =========================
 function encVarLen(v){ let buffer=v & 0x7F; const out=[]; while((v >>= 7)){ buffer <<= 8; buffer |= ((v & 0x7F) | 0x80); } while(true){ out.push(buffer & 0xFF); if(buffer & 0x80) buffer >>= 8; else break; } return new Uint8Array(out); }
@@ -314,6 +321,7 @@ const btnModeChord = $('#btnModeChord'); const btnModeScale = $('#btnModeScale')
 const wrapChord = $('#wrapChord'); const wrapScale = $('#wrapScale');
 const listenChord = $('#listenChord'); const listenScale = $('#listenScale'); const btnPlayStrum = $('#btnPlayStrum');
 const btnPlaySelChord = $('#btnPlaySelChord'); const btnPlaySelArp = $('#btnPlaySelArp');
+const heldSustainSnap = $('#heldSustainSnap');
 const tempoInput = $('#tempo');
 
 let mode = 'Chord';
@@ -374,10 +382,18 @@ function buildPiano(){ pianoHost.innerHTML=''; const container=document.createEl
   // White keys row
   const startMidi=midiFrom('C',3); const endMidi=midiFrom('F',5); const keys=[]; for(let m=startMidi;m<=endMidi;m++) keys.push(m); const whites=keys.filter(m=>![1,3,6,8,10].includes(mod(m,OCTAVE)));
   const whiteRow=document.createElement('div'); whiteRow.className='flex h-full'; shell.appendChild(whiteRow);
-  whites.forEach(m=>{ const pc=mod(m,OCTAVE); const k=document.createElement('div'); k.dataset.midi=String(m); k.dataset.pc=String(pc); k.className='white-key relative flex-1 mx-0.5 rounded-b-xl border bg-white border-slate-400'; const lbl=document.createElement('div'); lbl.className='absolute inset-x-0 bottom-1 text-center text-[10px] text-slate-700 select-none'; lbl.textContent = pcName(pc)+(Math.floor(m/OCTAVE)-1); k.appendChild(lbl); k.addEventListener('click', async (ev)=>{ if(ev.shiftKey){ toggleSelect(m); } else { await pluck(m, instrument, tempo); } updateBadges(); renderHighlights(); }); whiteRow.appendChild(k); });
+  whites.forEach(m=>{ const pc=mod(m,OCTAVE); const k=document.createElement('div'); k.dataset.midi=String(m); k.dataset.pc=String(pc); k.className='white-key relative flex-1 mx-0.5 rounded-b-xl border bg-white border-slate-400'; const lbl=document.createElement('div'); lbl.className='absolute inset-x-0 bottom-1 text-center text-[10px] text-slate-700 select-none'; lbl.textContent = pcName(pc)+(Math.floor(m/OCTAVE)-1); k.appendChild(lbl);
+    k.addEventListener('pointerdown', (ev)=>{ if(ev.shiftKey){ toggleSelect(m); updateBadges(); renderHighlights(); } else { k.setPointerCapture(ev.pointerId); k.dataset.start=String(performance.now()); } });
+    const end=(ev)=>{ const s=k.dataset.start; if(!s) return; let dur=(performance.now()-Number(s))/1000; dur=Math.min(6, Math.max(0.05, dur)); if(heldSustainSnap.checked){ const beat=60/tempo; const sixteenth=beat/4; dur=Math.round(dur/sixteenth)*sixteenth; } playMidiNotes([m],{instrument, tempo, noteDur:dur}); delete k.dataset.start; updateBadges(); renderHighlights(); };
+    k.addEventListener('pointerup', end); k.addEventListener('pointercancel', end);
+    whiteRow.appendChild(k); });
   // Black overlay (pointer-enabled only on keys)
   const overlay=document.createElement('div'); overlay.className='pointer-events-none absolute left-2 right-2 top-2 bottom-2 flex'; shell.appendChild(overlay);
-  keys.filter(m=>[1,3,6,8,10].includes(mod(m,OCTAVE))).forEach(m=>{ const pc=mod(m,OCTAVE); const wrap=document.createElement('div'); wrap.className='relative w-[6.66%] mx-[1.67%]'; wrap.style.visibility = [1,3,6,8,10].includes(pc)?'visible':'hidden'; const blk=document.createElement('div'); blk.dataset.midi=String(m); blk.dataset.pc=String(pc); blk.className='black-key absolute left-1/2 -translate-x-1/2 w-3/5 h-2/3 rounded-b-lg border bg-black border-black pointer-events-auto'; blk.title = pcName(pc)+(Math.floor(m/OCTAVE)-1); const lbl=document.createElement('div'); lbl.className='absolute inset-x-0 bottom-1 text-center text-[9px] text-rose-200 font-bold select-none'; lbl.textContent=''; blk.appendChild(lbl); blk.addEventListener('click', async (ev)=>{ if(ev.shiftKey){ toggleSelect(m); } else { await pluck(m, instrument, tempo); } updateBadges(); renderHighlights(); }); wrap.appendChild(blk); overlay.appendChild(wrap); });
+  keys.filter(m=>[1,3,6,8,10].includes(mod(m,OCTAVE))).forEach(m=>{ const pc=mod(m,OCTAVE); const wrap=document.createElement('div'); wrap.className='relative w-[6.66%] mx-[1.67%]'; wrap.style.visibility = [1,3,6,8,10].includes(pc)?'visible':'hidden'; const blk=document.createElement('div'); blk.dataset.midi=String(m); blk.dataset.pc=String(pc); blk.className='black-key absolute left-1/2 -translate-x-1/2 w-3/5 h-2/3 rounded-b-lg border bg-black border-black pointer-events-auto'; blk.title = pcName(pc)+(Math.floor(m/OCTAVE)-1); const lbl=document.createElement('div'); lbl.className='absolute inset-x-0 bottom-1 text-center text-[9px] text-rose-200 font-bold select-none'; lbl.textContent=''; blk.appendChild(lbl);
+    blk.addEventListener('pointerdown', (ev)=>{ if(ev.shiftKey){ toggleSelect(m); updateBadges(); renderHighlights(); } else { blk.setPointerCapture(ev.pointerId); blk.dataset.start=String(performance.now()); } });
+    const end=(ev)=>{ const s=blk.dataset.start; if(!s) return; let dur=(performance.now()-Number(s))/1000; dur=Math.min(6, Math.max(0.05, dur)); if(heldSustainSnap.checked){ const beat=60/tempo; const sixteenth=beat/4; dur=Math.round(dur/sixteenth)*sixteenth; } playMidiNotes([m],{instrument, tempo, noteDur:dur}); delete blk.dataset.start; updateBadges(); renderHighlights(); };
+    blk.addEventListener('pointerup', end); blk.addEventListener('pointercancel', end);
+    wrap.appendChild(blk); overlay.appendChild(wrap); });
   pianoHost.appendChild(container);
 }
 function toggleSelect(m){ if(selection.has(m)) selection.delete(m); else selection.add(m); }


### PR DESCRIPTION
## Summary
- add **heldSustainSnap** checkbox in Listen section to quantize held key sustain
- measure key hold time via pointer events and pass custom duration to playMidiNotes
- allow optional snapping to nearest 1/16 note at current tempo

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ace56b5bf4832cafb1dcd7166feb12