### PR TITLE
Add sequencer JSON and MIDI export

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -128,6 +128,13 @@
         </div>
         <canvas id="pianoRoll" width="800" height="200" class="w-full h-64 bg-slate-900 border border-slate-700"></canvas>
         <div id="seqTracks" class="space-y-2"></div>
+        <div class="flex flex-wrap gap-3 items-center">
+          <button id="seqExportJson" class="px-3 py-1 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm">Export JSON</button>
+          <button id="seqImportJson" class="px-3 py-1 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm">Import JSON</button>
+          <input id="seqImportFile" type="file" accept="application/json" class="hidden" />
+          <button id="seqExportMid" class="px-3 py-1 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm">Export MIDI</button>
+        </div>
+        <div id="seqStatus" class="text-xs text-slate-300"></div>
       </div>
     </section>
 
@@ -527,6 +534,11 @@ const sequencerHost = $('#sequencerHost');
 const seqPlay = $('#seqPlay'); const seqStop = $('#seqStop'); const seqBpm = $('#seqBpm');
 const seqLoop = $('#seqLoop'); const seqClick = $('#seqClick');
 const pianoRoll = $('#pianoRoll'); const seqTracks = $('#seqTracks');
+const seqExportJson = $('#seqExportJson');
+const seqImportJson = $('#seqImportJson');
+const seqImportFile = $('#seqImportFile');
+const seqExportMid = $('#seqExportMid');
+const seqStatus = $('#seqStatus');
 
 let mode = 'Chord';
 let instrument = 'Piano';
@@ -644,6 +656,47 @@ let clickId = null;
 
 setBpm(song.bpm);
 updateLoop();
+
+function serializeSong(){
+  return JSON.stringify(song, (k,v)=> k==='player' ? undefined : v);
+}
+
+function loadSong(data){
+  song.ppq = data.ppq;
+  song.bpm = data.bpm;
+  song.loop = data.loop;
+  song.tracks = data.tracks.map(t=>({ ...t, player:null }));
+  Tone.Transport.PPQ = song.ppq;
+  setBpm(song.bpm);
+  updateLoop();
+  initSequencer();
+  drawPianoRoll();
+  if(Tone.Transport.state==='started') scheduleSong();
+}
+
+function exportSongMidi(){
+  // Type-0 merged MIDI. TODO: implement Type-1 multi-track export.
+  const events = [];
+  song.tracks.forEach(track=>{
+    track.clips.forEach(clip=>{
+      clip.notes.forEach(n=>{
+        events.push({
+          start:(clip.start + n.tick)/song.ppq,
+          dur:n.dur/song.ppq,
+          midi:n.midi,
+          vel:Math.round((n.vel ?? 0.8)*127)
+        });
+      });
+    });
+  });
+  const bytes = buildMidi(events, song.ppq, song.bpm);
+  const blob = new Blob([bytes],{type:'audio/midi'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href=url; a.download='song.mid';
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(()=>URL.revokeObjectURL(url),1500);
+}
 
 function drawPianoRoll(){
   const ctx = pianoRoll.getContext('2d');
@@ -1384,6 +1437,41 @@ seqStop.addEventListener('click', ()=>{
   Tone.Transport.cancel();
   if(clickId!==null){ Tone.Transport.clear(clickId); clickId=null; }
   song.tracks.forEach(t=>{ if(t.player){ t.player.dispose(); t.player=null; } });
+});
+
+seqExportJson.addEventListener('click', ()=>{
+  const blob = new Blob([serializeSong()],{type:'application/json'});
+  const url = URL.createObjectURL(blob);
+  const a=document.createElement('a');
+  a.href=url; a.download='song.json';
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(()=>URL.revokeObjectURL(url),1500);
+  seqStatus.textContent='✅ Exported JSON';
+});
+
+seqImportJson.addEventListener('click', ()=> seqImportFile.click());
+
+seqImportFile.addEventListener('change', e=>{
+  const file = e.target.files[0];
+  if(!file) return;
+  const reader = new FileReader();
+  reader.onload = ev=>{
+    try {
+      const data = JSON.parse(ev.target.result);
+      loadSong(data);
+      seqStatus.textContent='✅ Imported JSON';
+    } catch(err){
+      console.error(err);
+      seqStatus.textContent='❌ Import failed';
+    }
+  };
+  reader.readAsText(file);
+  e.target.value='';
+});
+
+seqExportMid.addEventListener('click', ()=>{
+  exportSongMidi();
+  seqStatus.textContent='✅ Exported MIDI';
 });
 
 // Export buttons


### PR DESCRIPTION
## Summary
- add export/import controls and status area to sequencer UI
- implement JSON serialization/deserialization and hook up file import
- provide Type-0 MIDI export for sequencer songs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acedb345bc832c92616b4994e1a808