### PR TITLE
Preserve last note duration when creating new notes

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -701,6 +701,7 @@ const song = {
 Tone.Transport.PPQ = song.ppq;
 
 const SIXTEENTH = song.ppq / 4;
+let lastNoteDur = song.ppq * song.ts.num;
 const MIN_MIDI = midiFrom('C',2);
 const MAX_MIDI = MIN_MIDI + 4*12;
 let activeTrack = 0;
@@ -913,7 +914,7 @@ pianoRoll.addEventListener('pointerdown', ev => {
     }
   }
   // otherwise create new note
-  dragNote={tick, dur:SIXTEENTH, midi, mode:'new'};
+  dragNote={tick, dur:lastNoteDur, midi, mode:'new'};
   pianoRoll.setPointerCapture(ev.pointerId);
   drawPianoRoll();
 });
@@ -935,7 +936,10 @@ pianoRoll.addEventListener('pointermove', ev=>{
 });
 pianoRoll.addEventListener('pointerup', ev=>{
   if(!dragNote) return; const track=song.tracks[activeTrack];
-  if(dragNote.mode==='new') track.clips[0].notes.push({tick:dragNote.tick,dur:dragNote.dur,midi:dragNote.midi,vel:0.8});
+  if(dragNote.mode==='new') {
+    track.clips[0].notes.push({tick:dragNote.tick,dur:dragNote.dur,midi:dragNote.midi,vel:0.8});
+    lastNoteDur = dragNote.dur;
+  }
   // keep notes ordered after edits
   track.clips[0].notes.sort((a,b)=>a.tick-b.tick);
   dragNote=null; drawPianoRoll(); if(Tone.Transport.state==='started') scheduleSong(); pianoRoll.releasePointerCapture(ev.pointerId);


### PR DESCRIPTION
## Summary
- Track the duration of the most recently created note
- Use the last note duration when starting a new note in the sequencer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0977ba14832ca6fef26813e82aa3