### PR TITLE
Ensure piano UI rebuilds when reselected

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -3283,6 +3283,7 @@ function runTests(){
 
 // ========================= WIRING =========================
 function refreshInstruments(){
+  const isPiano = selInstr.value.startsWith('Piano');
   const isGuitar = selInstr.value.startsWith('Guitar') || selInstr.value.startsWith('Oud');
   const isBass = selInstr.value.startsWith('Bass');
   const isViolin = selInstr.value.startsWith('Violin');
@@ -3292,6 +3293,7 @@ function refreshInstruments(){
   const isSaxophone = selInstr.value.startsWith('Saxophone');
   const isKoto = selInstr.value.startsWith('Koto');
   const isNey = selInstr.value.startsWith('Ney');
+  pianoHost.classList.toggle('hidden', !isPiano);
   guitarHost.classList.toggle('hidden', !isGuitar);
   bassHost.classList.toggle('hidden', !isBass);
   violinHost.classList.toggle('hidden', !isViolin);
@@ -3301,6 +3303,7 @@ function refreshInstruments(){
   saxophoneHost.classList.toggle('hidden', !isSaxophone);
   kotoHost.classList.toggle('hidden', !isKoto);
   neyHost.classList.toggle('hidden', !isNey);
+  if(isPiano) buildPiano();
   if(!violinHost.classList.contains('hidden')) buildFretboard(violinHost, VIOLIN_TUNING,'Violin (12 positions)');
   if(!fluteHost.classList.contains('hidden')) buildFluteChart();
   if(!recorderHost.classList.contains('hidden')) buildRecorderChart();


### PR DESCRIPTION
## Summary
- Add `isPiano` flag in `refreshInstruments` to detect piano selection
- Toggle piano keyboard visibility and rebuild piano when switching back

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad23327d24832ca6c427d562bc1144