### PR TITLE
Handle Tone.js start errors

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -689,7 +689,17 @@ function createSeqInstrument(name){
   }
 }
 
-async function ensureTone(instr){ if(!_started){ try{ await Tone.start(); }catch{} _started=true; } if(!_synth){ _synth = new Tone.PolySynth(Tone.Synth).connect(masterLim); } const p=ENV[instr]||ENV.Piano; _synth.set({ envelope:{attack:p.a, decay:p.d, sustain:p.s, release:p.r}, oscillator:{type:p.osc} }); }
+async function ensureTone(instr){
+  if(!_started){
+    await Tone.start();
+    _started=true;
+  }
+  if(!_synth){
+    _synth = new Tone.PolySynth(Tone.Synth).connect(masterLim);
+  }
+  const p=ENV[instr]||ENV.Piano;
+  _synth.set({ envelope:{attack:p.a, decay:p.d, sustain:p.s, release:p.r}, oscillator:{type:p.osc} });
+}
 function midiName(m){ const pc=mod(m,OCTAVE), oct=Math.floor(m/OCTAVE)-1; return pcName(pc)+oct; }
 // Convert (possibly fractional) MIDI note numbers to Hz
 function midiToFreq(m){ return 440 * Math.pow(2, (m - 69) / 12); }
@@ -1341,10 +1351,11 @@ function updateLoop(){
   } else {
     // For one-shot playback, disable looping
     Tone.Transport.loop = false;
-    // Calculate song length based on actual notes
-    const maxNoteTick = Math.max(192*16, ...song.tracks.flatMap(t => 
-      t.clips[0].notes.map(n => t.clips[0].start + n.tick + n.dur)
-    ));
+    // Compute last note end across all tracks; fallback to at least 16 bars
+    const ends = song.tracks.flatMap(t =>
+      t.clips.flatMap(c => c.notes.map(n => c.start + n.tick + n.dur))
+    );
+    const maxNoteTick = ends.length ? Math.max(...ends) : 192 * 16;
     // Schedule a stop event at the end of the song
     autoStopId = Tone.Transport.scheduleOnce(() => {
       if(sequencerState === 'playing') {
@@ -1411,20 +1422,19 @@ function scheduleSong(changedIdx){
     // Create part only if there are events
     if(events.length > 0){
       try {
-        const part = new Tone.Part((time, n) => {
+        track.part = new Tone.Part((time, n) => {
           if(track.player && track.player.trigger) {
             track.player.trigger(n.midi, time, n.vel ?? 0.8, `${n.dur}i`);
           }
         }, events);
         if(seqLoop.checked && song.loop.enabled) {
-          part.loopStart = `${song.loop.start}i`;
-          part.loopEnd = `${song.loop.end}i`;
-          part.loop = true;
+          track.part.loopStart = `${song.loop.start}i`;
+          track.part.loopEnd = `${song.loop.end}i`;
+          track.part.loop = true;
         } else {
-          part.loop = false;
+          track.part.loop = false;
         }
-        part.start(0);
-        track.part = part;
+        track.part.start(0);
       } catch(error) {
         console.error(`Failed to create part for track ${idx}:`, error);
         track.part = null;


### PR DESCRIPTION
## Summary
- Defer setting `_started` until `Tone.start()` resolves
- Propagate `Tone.start()` errors so callers can display helpful messages
- Compute last note end across tracks for robust auto-stop scheduling
- Ensure rebuilt track parts start with correct loop settings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Chord-and-Keys/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ad2a00dd58832ca8c35c8233afbab3