### PR TITLE
Highlight selected piano keys

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -25,6 +25,7 @@
     body.skin-sunset { --bg-body: linear-gradient(180deg, #0b486b 0%, #f56217 100%); --text-body: #fef3c7; }
     #devTests .chevron { display:inline-block; transition: transform 0.2s; transform: rotate(-90deg); }
     #devTests[open] .chevron { transform: rotate(0deg); }
+    .key-selected { box-shadow: 0 0 5px 2px rgba(34,197,94,.7); }
   </style>
 </head>
 <body class="min-h-screen w-full skin-default">
@@ -2045,20 +2046,20 @@ function buildPiano(){ pianoHost.innerHTML=''; const container=document.createEl
   const startMidi=midiFrom('C',3); const endMidi=midiFrom('F',5); const keys=[]; for(let m=startMidi;m<=endMidi;m++) keys.push(m); const whites=keys.filter(m=>![1,3,6,8,10].includes(mod(m,OCTAVE)));
   const whiteRow=document.createElement('div'); whiteRow.className='flex h-full'; shell.appendChild(whiteRow);
   whites.forEach(m=>{ const pc=mod(m,OCTAVE); const k=document.createElement('div'); k.dataset.midi=String(m); k.dataset.pc=String(pc); k.className='white-key relative flex-1 mx-0.5 rounded-b-xl border bg-white border-slate-400'; const lbl=document.createElement('div'); lbl.className='absolute inset-x-0 bottom-1 text-center text-[10px] text-slate-700 select-none'; lbl.textContent = pcName(pc)+(Math.floor(m/OCTAVE)-1); k.appendChild(lbl);
-    k.addEventListener('pointerdown', (ev)=>{ if(ev.shiftKey){ toggleSelect(m); updateBadges(); renderHighlights(); } else { pressHeld(m); k.setPointerCapture(ev.pointerId); k.dataset.held='1'; } });
+    k.addEventListener('pointerdown', (ev)=>{ if(ev.shiftKey){ toggleSelect(m); } else { pressHeld(m); k.setPointerCapture(ev.pointerId); k.dataset.held='1'; } });
     const end=(ev)=>{ if(!k.dataset.held) return; releaseHeld(m); delete k.dataset.held; updateBadges(); renderHighlights(); };
     k.addEventListener('pointerup', end); k.addEventListener('pointercancel', end);
     whiteRow.appendChild(k); });
   // Black overlay (pointer-enabled only on keys)
   const overlay=document.createElement('div'); overlay.className='pointer-events-none absolute left-2 right-2 top-2 bottom-2 flex'; shell.appendChild(overlay);
   keys.filter(m=>[1,3,6,8,10].includes(mod(m,OCTAVE))).forEach(m=>{ const pc=mod(m,OCTAVE); const wrap=document.createElement('div'); wrap.className='relative w-[6.66%] mx-[1.67%]'; wrap.style.visibility = [1,3,6,8,10].includes(pc)?'visible':'hidden'; const blk=document.createElement('div'); blk.dataset.midi=String(m); blk.dataset.pc=String(pc); blk.className='black-key absolute left-1/2 -translate-x-1/2 w-3/5 h-2/3 rounded-b-lg border bg-black border-black pointer-events-auto'; blk.title = pcName(pc)+(Math.floor(m/OCTAVE)-1); const lbl=document.createElement('div'); lbl.className='absolute inset-x-0 bottom-1 text-center text-[9px] text-rose-200 font-bold select-none'; lbl.textContent=''; blk.appendChild(lbl);
-    blk.addEventListener('pointerdown', (ev)=>{ if(ev.shiftKey){ toggleSelect(m); updateBadges(); renderHighlights(); } else { pressHeld(m); blk.setPointerCapture(ev.pointerId); blk.dataset.held='1'; } });
+    blk.addEventListener('pointerdown', (ev)=>{ if(ev.shiftKey){ toggleSelect(m); } else { pressHeld(m); blk.setPointerCapture(ev.pointerId); blk.dataset.held='1'; } });
     const end=(ev)=>{ if(!blk.dataset.held) return; releaseHeld(m); delete blk.dataset.held; updateBadges(); renderHighlights(); };
     blk.addEventListener('pointerup', end); blk.addEventListener('pointercancel', end);
     wrap.appendChild(blk); overlay.appendChild(wrap); });
   pianoHost.appendChild(container);
 }
-function toggleSelect(m){ if(selection.has(m)) selection.delete(m); else selection.add(m); }
+function toggleSelect(m){ if(selection.has(m)) selection.delete(m); else selection.add(m); updateBadges(); renderHighlights(); }
 function clearSelection(){ selection.clear(); updateBadges(); renderHighlights(); }
 function renderHighlights(){ const {pcset, rootPc} = computeSelected(); // visual highlight comes from chosen chord/scale
   // Whites (robust selector — no Tailwind arbitrary value in query)
@@ -2066,6 +2067,8 @@ function renderHighlights(){ const {pcset, rootPc} = computeSelected(); // visua
     const rootBadge = el.querySelector('.rootbadge'); if(rootBadge) rootBadge.remove(); if(rootPc===pc){ const b=document.createElement('div'); b.className='rootbadge absolute inset-x-0 bottom-1 text-center text-[10px] text-rose-600 font-bold'; b.textContent='ROOT'; el.appendChild(b); } });
   // Blacks (robust selector)
   pianoHost.querySelectorAll('.black-key').forEach((el)=>{ const m=Number(el.dataset.midi); const pc=mod(m,OCTAVE); const active=pcset.has(pc); el.className = 'black-key absolute left-1/2 -translate-x-1/2 w-3/5 h-2/3 rounded-b-lg border '+(active? 'bg-indigo-400 border-indigo-600':'bg-black border-black')+' pointer-events-auto'; const r=el.querySelector('.rootchar'); if(r) r.remove(); if(rootPc===pc){ const rr=document.createElement('div'); rr.className='rootchar absolute inset-x-0 bottom-1 text-center text-[9px] text-rose-200 font-bold'; rr.textContent='R'; el.appendChild(rr); } });
+  // Selection highlights
+  selection.forEach((m)=>{ const el = pianoHost.querySelector(`[data-midi="${m}"]`); if(el) el.classList.add('key-selected'); });
 }
 
 // ========================= FRETBOARDS =========================


### PR DESCRIPTION
## Summary
- Add `.key-selected` CSS class for green glow on chosen notes
- Sync selection state by updating highlights inside `toggleSelect` and `clearSelection`
- Extend `renderHighlights` to apply selection glow to corresponding keys

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad48719204832ca14e33964ea59ca1