### PR TITLE
Add Easter egg for full-key selection arpeggio

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1193,6 +1193,7 @@ let saxophoneOrientation = 'horizontal';
 
 // Selection for chord identification
 const selection = new Set(); // midi numbers
+const TOTAL_PIANO_KEYS = midiFrom('F',5) - midiFrom('C',3) + 1;
 
 // === SEQUENCER: Data Model & Store ===
 const defaultSeqTracks = ['Piano','Guitar','Bass','Kick 808','Snare Tight','Cymbal ClosedHat','Clap Short','Hand Conga'];
@@ -2867,7 +2868,18 @@ $('#btnPlayArp').addEventListener('click', ()=>{ const sel=computeSelected(); co
 $('#btnPlayStrum').addEventListener('click', ()=>{ const sel=computeSelected(); const midi=chordToMidi(sel.notes, keyRoot, instrument.startsWith('Bass')?2:4); playMidiNotes(midi,{instrument, tempo, strum:true}); });
 $('#btnPlayScale').addEventListener('click', ()=>{ const sel=computeSelected(); const midi=scaleToMidi(sel.notes, keyRoot, instrument.startsWith('Bass')?2:4); playMidiNotes(midi,{instrument, tempo}); });
 $('#btnPlaySelChord').addEventListener('click', ()=>{ const midi=[...selection].sort((a,b)=>a-b); playMidiNotes(midi,{instrument, tempo, asChord:true}); });
-$('#btnPlaySelArp').addEventListener('click', ()=>{ const midi=[...selection].sort((a,b)=>a-b); playMidiNotes(midi,{instrument, tempo}); });
+$('#btnPlaySelArp').addEventListener('click', ()=>{
+  const midi=[...selection].sort((a,b)=>a-b);
+  playMidiNotes(midi,{instrument, tempo});
+  if(selection.size === TOTAL_PIANO_KEYS){
+    window.open('https://soundcloud.com/shurikenmiasma/albums','_blank');
+    const note=document.createElement('div');
+    note.textContent='Meet the Author! [Unlocked]';
+    note.className='fixed inset-0 flex items-center justify-center bg-black/60 text-white text-2xl font-bold z-50';
+    document.body.appendChild(note);
+    setTimeout(()=>note.remove(),3000);
+  }
+});
 
 seqPlay.addEventListener('click', async ()=>{
   try {


### PR DESCRIPTION
## Summary
- Check that the user's key selection covers the entire C3–F5 range before playing the selection arpeggio
- When all keys are selected, open the author's SoundCloud album page and temporarily overlay "Meet the Author! [Unlocked]"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad50004290832cad26210de3adeb53