### PR TITLE
Ensure sequencer stops after final note

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1423,16 +1423,20 @@ function updateLoop(){
   } else {
     // For one-shot playback, disable looping
     Tone.Transport.loop = false;
-    // Calculate song length based on actual notes
-    const maxNoteTick = Math.max(192*16, ...song.tracks.flatMap(t => 
-      t.clips[0].notes.map(n => t.clips[0].start + n.tick + n.dur)
-    ));
-    // Schedule a stop event at the end of the song
+    // Determine the latest note end across all tracks
+    const maxNoteTick = Math.max(
+      0,
+      ...song.tracks.flatMap(t =>
+        t.clips.flatMap(c => c.notes.map(n => c.start + n.tick + n.dur))
+      )
+    );
+    // Schedule a stop event slightly after the final note
+    const buffer = 192; // allow trailing releases
     autoStopId = Tone.Transport.scheduleOnce(() => {
       if(sequencerState === 'playing') {
         seqStop.click();
       }
-    }, `${maxNoteTick + 192}i`); // Add small buffer
+    }, `${maxNoteTick + buffer}i`);
   }
 }
 


### PR DESCRIPTION
## Summary
- compute the end of playback from the latest note across all tracks
- schedule an auto-stop event after the final note with a small buffer

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad61fd936c832cb3c6106d4b6600c5