### PR TITLE
feat: add recorder svg and refactor chart

### DIFF
--- a/assets/instruments/recorder.svg
+++ b/assets/instruments/recorder.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 100">
+  <g id="instrument">
+    <path id="body" d="M20 35h300a15 15 0 0 1 0 30H20a15 15 0 0 1 0-30z"/>
+    <circle id="hole0" cx="85" cy="50" r="6"/>
+    <circle id="hole1" cx="100" cy="50" r="6"/>
+    <circle id="hole2" cx="115" cy="50" r="6"/>
+    <circle id="hole3" cx="130" cy="50" r="6"/>
+    <circle id="hole4" cx="150" cy="50" r="6"/>
+    <circle id="hole5" cx="170" cy="50" r="6"/>
+    <circle id="hole6" cx="190" cy="50" r="6"/>
+    <circle id="hole7" cx="210" cy="50" r="6"/>
+    <ellipse id="thumb" cx="95" cy="32" rx="3" ry="2"/>
+  </g>
+</svg>

--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1685,25 +1685,15 @@ function drawPianoRoll(){
   const cellH = 20 * ui.zoomY;
   let totalWidth = totalSteps * cellW;
   
-  // Debug logging for large MIDI files
-  if(clip.length > 192*64) {
-    console.log('Large MIDI detected - clip.length:', clip.length, 'totalSteps:', totalSteps, 'totalWidth:', totalWidth, 'cellW:', cellW);
-    
-    // Check for browser width limits
-    const maxBrowserWidth = 33554427; // Chrome/Firefox limit
-    if(totalWidth > maxBrowserWidth) {
-      console.warn('totalWidth exceeds browser limit:', totalWidth, '> max:', maxBrowserWidth);
-      // Reduce zoom to fit within browser limits
-      const maxZoomX = maxBrowserWidth / (totalSteps * 20);
-      if(ui.zoomX > maxZoomX) {
-        console.log('Reducing zoomX from', ui.zoomX, 'to', maxZoomX);
-        ui.zoomX = maxZoomX;
-        seqZoomX.value = maxZoomX;
-        // Recalculate with new zoom
-        cellW = 20 * ui.zoomX;
-        totalWidth = totalSteps * cellW;
-        console.log('Adjusted totalWidth:', totalWidth);
-      }
+  // Ensure we don't exceed browser canvas size limits
+  const maxBrowserWidth = 33554427; // Chrome/Firefox limit
+  if(totalWidth > maxBrowserWidth) {
+    const maxZoomX = maxBrowserWidth / (totalSteps * 20);
+    if(ui.zoomX > maxZoomX) {
+      ui.zoomX = maxZoomX;
+      seqZoomX.value = maxZoomX;
+      cellW = 20 * ui.zoomX;
+      totalWidth = totalSteps * cellW;
     }
   }
   const scrollLeft = pianoRollScroll.scrollLeft;
@@ -2342,6 +2332,7 @@ const FLUTE_FINGERINGS = {
   Change these numbers to resize the chart or adjust hole placement for custom layouts.
 */
 let fluteBodyPath = null;
+const FLUTE_BODY_FALLBACK = 'M5 25h310a15 15 0 0 1 0 30H5a15 15 0 0 1 0-30z';
 async function buildFluteChart(){
   const {rootPc} = computeSelected();
   const note = pcName(rootPc);
@@ -2359,9 +2350,13 @@ async function buildFluteChart(){
   svg.style.transform = (isHoriz? '' : 'rotate(90deg)') + (fluteLeftToRight ? '' : ' scaleX(-1)');
 
   if(!fluteBodyPath){
-    const txt = await fetch('assets/instruments/flute.svg').then(r=>r.text());
-    const doc = new DOMParser().parseFromString(txt,'image/svg+xml');
-    fluteBodyPath = doc.querySelector('path').getAttribute('d');
+    try{
+      const txt = await fetch('assets/instruments/flute.svg').then(r=>r.text());
+      const doc = new DOMParser().parseFromString(txt,'image/svg+xml');
+      fluteBodyPath = doc.querySelector('path').getAttribute('d');
+    }catch(e){
+      fluteBodyPath = FLUTE_BODY_FALLBACK;
+    }
   }
   const body = document.createElementNS(svgNS,'path');
   body.setAttribute('d', fluteBodyPath);
@@ -2454,294 +2449,51 @@ const RECORDER_FINGERINGS = {
   - Hole radius: r=8
   Adjust these values to change chart size, spacing, or hole size for custom recorders.
 */
-function buildRecorderChart(){
+let recorderSvgTxt = null;
+const RECORDER_SVG_FALLBACK = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 100"><g id="instrument"><path id="body" d="M20 35h300a15 15 0 0 1 0 30H20a15 15 0 0 1 0-30z"/><circle id="hole0" cx="85" cy="50" r="6"/><circle id="hole1" cx="100" cy="50" r="6"/><circle id="hole2" cx="115" cy="50" r="6"/><circle id="hole3" cx="130" cy="50" r="6"/><circle id="hole4" cx="150" cy="50" r="6"/><circle id="hole5" cx="170" cy="50" r="6"/><circle id="hole6" cx="190" cy="50" r="6"/><circle id="hole7" cx="210" cy="50" r="6"/><ellipse id="thumb" cx="95" cy="32" rx="3" ry="2"/></g></svg>`;
+async function buildRecorderChart(){
   const {rootPc} = computeSelected();
   const note = pcName(rootPc);
   const sharp = ENHARMONIC_MAP[note] || note;
   const fing = RECORDER_FINGERINGS[sharp] || [0,0,0,0,0,0,0,0];
   recorderHost.innerHTML='';
   const svgNS='http://www.w3.org/2000/svg';
-  const svg=document.createElementNS(svgNS,'svg');
   const isHoriz = recorderOrientation === 'horizontal';
-  svg.setAttribute('viewBox', isHoriz ? '0 0 340 100' : '0 0 100 340');
-  svg.setAttribute('class','mx-auto');
-  
-  // Realistic recorder with proper woodwind details
-  if(isHoriz){
-    // Wood gradient for realistic wooden appearance
-    const grad = document.createElementNS(svgNS,'defs');
-    const gradDef = document.createElementNS(svgNS,'linearGradient');
-    gradDef.setAttribute('id','woodGrad');
-    gradDef.setAttribute('x1','0%');
-    gradDef.setAttribute('y1','0%');
-    gradDef.setAttribute('x2','0%');
-    gradDef.setAttribute('y2','100%');
-    const stop1 = document.createElementNS(svgNS,'stop');
-    stop1.setAttribute('offset','0%');
-    stop1.setAttribute('stop-color','#d97706');
-    const stop2 = document.createElementNS(svgNS,'stop');
-    stop2.setAttribute('offset','25%');
-    stop2.setAttribute('stop-color','#b45309');
-    const stop3 = document.createElementNS(svgNS,'stop');
-    stop3.setAttribute('offset','75%');
-    stop3.setAttribute('stop-color','#92400e');
-    const stop4 = document.createElementNS(svgNS,'stop');
-    stop4.setAttribute('offset','100%');
-    stop4.setAttribute('stop-color','#78350f');
-    [stop1,stop2,stop3,stop4].forEach(s=>gradDef.appendChild(s));
-    grad.appendChild(gradDef);
-    svg.appendChild(grad);
-    
-    // Mouthpiece/head section with beak
-    const headSection = document.createElementNS(svgNS,'rect');
-    headSection.setAttribute('x', recorderLeftToRight ? '10' : '270');
-    headSection.setAttribute('y','35');
-    headSection.setAttribute('width','60');
-    headSection.setAttribute('height','30');
-    headSection.setAttribute('rx','15');
-    headSection.setAttribute('fill','url(#woodGrad)');
-    headSection.setAttribute('stroke','#92400e');
-    headSection.setAttribute('stroke-width','2');
-    svg.appendChild(headSection);
-    
-    // Beak (windway)
-    const beak = document.createElementNS(svgNS,'polygon');
-    const beakPoints = recorderLeftToRight ? 
-      '10,45 25,40 25,60 10,55' : 
-      '330,45 315,40 315,60 330,55';
-    beak.setAttribute('points', beakPoints);
-    beak.setAttribute('fill','#78350f');
-    beak.setAttribute('stroke','#451a03');
-    beak.setAttribute('stroke-width','1.5');
-    svg.appendChild(beak);
-    
-    // Upper joint (joint with thumb hole)
-    const upperJoint = document.createElementNS(svgNS,'rect');
-    upperJoint.setAttribute('x', recorderLeftToRight ? '75' : '205');
-    upperJoint.setAttribute('y','37');
-    upperJoint.setAttribute('width','60');
-    upperJoint.setAttribute('height','26');
-    upperJoint.setAttribute('rx','13');
-    upperJoint.setAttribute('fill','url(#woodGrad)');
-    upperJoint.setAttribute('stroke','#92400e');
-    upperJoint.setAttribute('stroke-width','2');
-    svg.appendChild(upperJoint);
-    
-    // Lower joint
-    const lowerJoint = document.createElementNS(svgNS,'rect');
-    lowerJoint.setAttribute('x', recorderLeftToRight ? '140' : '140');
-    lowerJoint.setAttribute('y','38');
-    lowerJoint.setAttribute('width','60');
-    lowerJoint.setAttribute('height','24');
-    lowerJoint.setAttribute('rx','12');
-    lowerJoint.setAttribute('fill','url(#woodGrad)');
-    lowerJoint.setAttribute('stroke','#92400e');
-    lowerJoint.setAttribute('stroke-width','2');
-    svg.appendChild(lowerJoint);
-    
-    // Foot joint
-    const footJoint = document.createElementNS(svgNS,'rect');
-    footJoint.setAttribute('x', recorderLeftToRight ? '205' : '75');
-    footJoint.setAttribute('y','39');
-    footJoint.setAttribute('width','60');
-    footJoint.setAttribute('height','22');
-    footJoint.setAttribute('rx','11');
-    footJoint.setAttribute('fill','url(#woodGrad)');
-    footJoint.setAttribute('stroke','#92400e');
-    footJoint.setAttribute('stroke-width','2');
-    svg.appendChild(footJoint);
-    
-    // Joint rings for realism
-    const rings = recorderLeftToRight ? [70, 135, 200] : [270, 205, 140];
-    rings.forEach(x => {
-      const ring = document.createElementNS(svgNS,'line');
-      ring.setAttribute('x1', String(x));
-      ring.setAttribute('y1','35');
-      ring.setAttribute('x2', String(x));
-      ring.setAttribute('y2','65');
-      ring.setAttribute('stroke','#451a03');
-      ring.setAttribute('stroke-width','2');
-      svg.appendChild(ring);
-    });
-    
-    // Tone holes with realistic spacing
-    const holePositions = recorderLeftToRight ? 
-      [85, 100, 115, 130, 150, 170, 190, 210] : 
-      [255, 240, 225, 210, 190, 170, 150, 130];
-    
-    fing.forEach((closed,i)=>{
-      const holeX = holePositions[i];
-      
-      // Tone hole
-      const hole = document.createElementNS(svgNS,'circle');
-      hole.setAttribute('cx', String(holeX));
-      hole.setAttribute('cy','50');
-      hole.setAttribute('r','6');
-      hole.setAttribute('fill', closed ? '#451a03' : '#1c1917');
-      hole.setAttribute('stroke','#78350f');
-      hole.setAttribute('stroke-width','1.5');
-      svg.appendChild(hole);
-      
-      // Finger coverage indication
-      if(closed) {
-        const finger = document.createElementNS(svgNS,'circle');
-        finger.setAttribute('cx', String(holeX));
-        finger.setAttribute('cy','50');
-        finger.setAttribute('r','9');
-        finger.setAttribute('fill','rgba(251, 191, 36, 0.7)');
-        finger.setAttribute('stroke','#f59e0b');
-        finger.setAttribute('stroke-width','2');
-        svg.appendChild(finger);
-      }
-    });
-    
-    // Thumb hole (back side, shown as small indicator)
-    const thumbHole = document.createElementNS(svgNS,'ellipse');
-    thumbHole.setAttribute('cx', recorderLeftToRight ? '95' : '245');
-    thumbHole.setAttribute('cy','32');
-    thumbHole.setAttribute('rx','3');
-    thumbHole.setAttribute('ry','2');
-    thumbHole.setAttribute('fill','#1c1917');
-    thumbHole.setAttribute('stroke','#78350f');
-    thumbHole.setAttribute('stroke-width','1');
-    svg.appendChild(thumbHole);
-    
-  } else {
-    // Vertical orientation - similar detailed structure
-    const grad = document.createElementNS(svgNS,'defs');
-    const gradDef = document.createElementNS(svgNS,'linearGradient');
-    gradDef.setAttribute('id','woodGradV');
-    gradDef.setAttribute('x1','0%');
-    gradDef.setAttribute('y1','0%');
-    gradDef.setAttribute('x2','100%');
-    gradDef.setAttribute('y2','0%');
-    const stop1 = document.createElementNS(svgNS,'stop');
-    stop1.setAttribute('offset','0%');
-    stop1.setAttribute('stop-color','#d97706');
-    const stop2 = document.createElementNS(svgNS,'stop');
-    stop2.setAttribute('offset','25%');
-    stop2.setAttribute('stop-color','#b45309');
-    const stop3 = document.createElementNS(svgNS,'stop');
-    stop3.setAttribute('offset','75%');
-    stop3.setAttribute('stop-color','#92400e');
-    const stop4 = document.createElementNS(svgNS,'stop');
-    stop4.setAttribute('offset','100%');
-    stop4.setAttribute('stop-color','#78350f');
-    [stop1,stop2,stop3,stop4].forEach(s=>gradDef.appendChild(s));
-    grad.appendChild(gradDef);
-    svg.appendChild(grad);
-    
-    // Head section vertical
-    const headSection = document.createElementNS(svgNS,'rect');
-    headSection.setAttribute('x','35');
-    headSection.setAttribute('y', recorderLeftToRight ? '10' : '270');
-    headSection.setAttribute('width','30');
-    headSection.setAttribute('height','60');
-    headSection.setAttribute('rx','15');
-    headSection.setAttribute('fill','url(#woodGradV)');
-    headSection.setAttribute('stroke','#92400e');
-    headSection.setAttribute('stroke-width','2');
-    svg.appendChild(headSection);
-    
-    // Beak vertical
-    const beak = document.createElementNS(svgNS,'polygon');
-    const beakPoints = recorderLeftToRight ? 
-      '45,10 40,25 60,25 55,10' : 
-      '45,330 40,315 60,315 55,330';
-    beak.setAttribute('points', beakPoints);
-    beak.setAttribute('fill','#78350f');
-    beak.setAttribute('stroke','#451a03');
-    beak.setAttribute('stroke-width','1.5');
-    svg.appendChild(beak);
-    
-    // Joints vertical
-    const upperJoint = document.createElementNS(svgNS,'rect');
-    upperJoint.setAttribute('x','37');
-    upperJoint.setAttribute('y', recorderLeftToRight ? '75' : '205');
-    upperJoint.setAttribute('width','26');
-    upperJoint.setAttribute('height','60');
-    upperJoint.setAttribute('rx','13');
-    upperJoint.setAttribute('fill','url(#woodGradV)');
-    upperJoint.setAttribute('stroke','#92400e');
-    upperJoint.setAttribute('stroke-width','2');
-    svg.appendChild(upperJoint);
-    
-    const lowerJoint = document.createElementNS(svgNS,'rect');
-    lowerJoint.setAttribute('x','38');
-    lowerJoint.setAttribute('y','140');
-    lowerJoint.setAttribute('width','24');
-    lowerJoint.setAttribute('height','60');
-    lowerJoint.setAttribute('rx','12');
-    lowerJoint.setAttribute('fill','url(#woodGradV)');
-    lowerJoint.setAttribute('stroke','#92400e');
-    lowerJoint.setAttribute('stroke-width','2');
-    svg.appendChild(lowerJoint);
-    
-    const footJoint = document.createElementNS(svgNS,'rect');
-    footJoint.setAttribute('x','39');
-    footJoint.setAttribute('y', recorderLeftToRight ? '205' : '75');
-    footJoint.setAttribute('width','22');
-    footJoint.setAttribute('height','60');
-    footJoint.setAttribute('rx','11');
-    footJoint.setAttribute('fill','url(#woodGradV)');
-    footJoint.setAttribute('stroke','#92400e');
-    footJoint.setAttribute('stroke-width','2');
-    svg.appendChild(footJoint);
-    
-    // Joint rings vertical
-    const rings = recorderLeftToRight ? [70, 135, 200] : [270, 205, 140];
-    rings.forEach(y => {
-      const ring = document.createElementNS(svgNS,'line');
-      ring.setAttribute('x1','35');
-      ring.setAttribute('y1', String(y));
-      ring.setAttribute('x2','65');
-      ring.setAttribute('y2', String(y));
-      ring.setAttribute('stroke','#451a03');
-      ring.setAttribute('stroke-width','2');
-      svg.appendChild(ring);
-    });
-    
-    // Tone holes vertical
-    const holePositions = recorderLeftToRight ? 
-      [85, 100, 115, 130, 150, 170, 190, 210] : 
-      [255, 240, 225, 210, 190, 170, 150, 130];
-    
-    fing.forEach((closed,i)=>{
-      const holeY = holePositions[i];
-      
-      const hole = document.createElementNS(svgNS,'circle');
-      hole.setAttribute('cx','50');
-      hole.setAttribute('cy', String(holeY));
-      hole.setAttribute('r','6');
-      hole.setAttribute('fill', closed ? '#451a03' : '#1c1917');
-      hole.setAttribute('stroke','#78350f');
-      hole.setAttribute('stroke-width','1.5');
-      svg.appendChild(hole);
-      
-      if(closed) {
-        const finger = document.createElementNS(svgNS,'circle');
-        finger.setAttribute('cx','50');
-        finger.setAttribute('cy', String(holeY));
-        finger.setAttribute('r','9');
-        finger.setAttribute('fill','rgba(251, 191, 36, 0.7)');
-        finger.setAttribute('stroke','#f59e0b');
-        finger.setAttribute('stroke-width','2');
-        svg.appendChild(finger);
-      }
-    });
-    
-    // Thumb hole vertical
-    const thumbHole = document.createElementNS(svgNS,'ellipse');
-    thumbHole.setAttribute('cx','68');
-    thumbHole.setAttribute('cy', recorderLeftToRight ? '95' : '245');
-    thumbHole.setAttribute('rx','2');
-    thumbHole.setAttribute('ry','3');
-    thumbHole.setAttribute('fill','#1c1917');
-    thumbHole.setAttribute('stroke','#78350f');
-    thumbHole.setAttribute('stroke-width','1');
-    svg.appendChild(thumbHole);
+  const wrapper=document.createElementNS(svgNS,'svg');
+  wrapper.setAttribute('viewBox', isHoriz ? '0 0 340 100' : '0 0 100 340');
+  wrapper.setAttribute('class','mx-auto');
+  wrapper.style.width = isHoriz ? '340px' : '100px';
+  wrapper.style.height = isHoriz ? '100px' : '340px';
+  if(!recorderSvgTxt){
+    try{ recorderSvgTxt = await fetch('assets/instruments/recorder.svg').then(r=>r.text()); }
+    catch(e){ recorderSvgTxt = RECORDER_SVG_FALLBACK; }
   }
-  recorderHost.appendChild(svg);
+  const doc=new DOMParser().parseFromString(recorderSvgTxt,'image/svg+xml');
+  const instrument=doc.getElementById('instrument');
+  const body=doc.getElementById('body');
+  const holes=[...instrument.querySelectorAll('[id^=hole]')];
+  const thumb=doc.getElementById('thumb');
+  const defs=document.createElementNS(svgNS,'defs');
+  const grad=document.createElementNS(svgNS,'linearGradient');
+  grad.id='recWood';
+  if(isHoriz){ grad.setAttribute('x1','0%'); grad.setAttribute('y1','0%'); grad.setAttribute('x2','0%'); grad.setAttribute('y2','100%'); }
+  else { grad.setAttribute('x1','0%'); grad.setAttribute('y1','0%'); grad.setAttribute('x2','100%'); grad.setAttribute('y2','0%'); }
+  ['#d97706','#b45309','#92400e','#78350f'].forEach((c,i)=>{ const stop=document.createElementNS(svgNS,'stop'); stop.setAttribute('offset',`${i*100/3}%`); stop.setAttribute('stop-color',c); grad.appendChild(stop); });
+  defs.appendChild(grad);
+  wrapper.appendChild(defs);
+  body.setAttribute('fill','url(#recWood)');
+  body.setAttribute('stroke','#92400e');
+  body.setAttribute('stroke-width','2');
+  holes.forEach((hole,i)=>{ hole.setAttribute('fill','#1c1917'); hole.setAttribute('stroke','#78350f'); hole.setAttribute('stroke-width','1.5'); if(fing[i]) hole.setAttribute('transform','translate(0,2)'); else hole.removeAttribute('transform'); });
+  thumb.setAttribute('fill','#1c1917');
+  thumb.setAttribute('stroke','#78350f');
+  thumb.setAttribute('stroke-width','1');
+  let trans='';
+  if(!isHoriz) trans+='rotate(90 170 50)';
+  if(!recorderLeftToRight){ trans+=(trans?' ':'')+(isHoriz?'scale(-1,1) translate(-340,0)':'scale(1,-1) translate(0,-340)'); }
+  if(trans) instrument.setAttribute('transform',trans);
+  wrapper.appendChild(instrument);
+  recorderHost.appendChild(wrapper);
   const flip=document.createElement('button');
   flip.id='recorderFlip';
   flip.textContent = isHoriz ? 'Flip ↔' : 'Flip ↕';
@@ -2756,14 +2508,8 @@ function buildRecorderChart(){
   lbl.className='mt-2 text-center text-xs text-slate-400';
   lbl.textContent=`Fingering for ${sharp}`;
   recorderHost.appendChild(lbl);
-  document.getElementById('recorderFlip').onclick = () => {
-    recorderLeftToRight = !recorderLeftToRight;
-    buildRecorderChart();
-  };
-  document.getElementById('recorderOrient').onclick = () => {
-    recorderOrientation = recorderOrientation === 'horizontal' ? 'vertical' : 'horizontal';
-    buildRecorderChart();
-  };
+  document.getElementById('recorderFlip').onclick = () => { recorderLeftToRight = !recorderLeftToRight; buildRecorderChart(); };
+  document.getElementById('recorderOrient').onclick = () => { recorderOrientation = recorderOrientation === 'horizontal' ? 'vertical' : 'horizontal'; buildRecorderChart(); };
 }
 
 // ========================= TRUMPET CHART =========================


### PR DESCRIPTION
## Summary
- add recorder SVG asset
- replace manual recorder drawing with imported path and gradient
- ensure recorder and flute SVGs render with fallbacks and fixed sizing
- prevent piano roll from exceeding browser width limits

## Testing
- `npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68ad778a1858832c91c3f2dcdcee881e