### PR TITLE
fix: initialize UI if DOM already loaded

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -4950,8 +4950,8 @@ PC Keyboard Layout:
   alert(layout);
 }
 
-// Wait for DOM to be fully loaded before initializing
-document.addEventListener('DOMContentLoaded', () => {
+// Initialize the application once the DOM is ready
+function initApp() {
   console.log('DOM fully loaded, initializing application...');
   
   // Initialize DOM element references
@@ -6454,7 +6454,14 @@ if(devTests){
 
 }
 
-}); // End of DOMContentLoaded callback
+} // End of initApp
+
+// Run initialization now if the DOM is already loaded, otherwise wait
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initApp);
+} else {
+  initApp();
+}
 </script>
 
 <!-- Context Menu -->


### PR DESCRIPTION
## Summary
- ensure app setup runs even when DOMContentLoaded already fired

## Testing
- `npx mocha tests/mode-switch.test.js tests/midiPlayback.test.js`
- `npx mocha tests/*.test.js` *(fails: ReferenceError: test is not defined)*
- `npx -y jest tests/production-mode.test.js` *(fails: Config paths must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae48210b44832c847343f66c715665