### PR TITLE
Fix tab navigation and dropdown behaviour

### DIFF
--- a/chord-scale-library-react/src/components/Dropdown.tsx
+++ b/chord-scale-library-react/src/components/Dropdown.tsx
@@ -25,7 +25,9 @@ const Dropdown: React.FC<DropdownProps> = ({
         className={`inline-flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium bg-gray-700 text-gray-300 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
       >
         <SelectPrimitive.Value placeholder={placeholder} />
-        <SelectPrimitive.Icon className="h-4 w-4 opacity-50" />
+        <SelectPrimitive.Icon className="h-4 w-4 opacity-50">
+          ▼
+        </SelectPrimitive.Icon>
       </SelectPrimitive.Trigger>
       
       <SelectPrimitive.Portal>

--- a/chord-scale-library-react/src/components/Tabs.tsx
+++ b/chord-scale-library-react/src/components/Tabs.tsx
@@ -20,7 +20,6 @@ const Tabs: React.FC<TabsProps> = ({
   return (
     <TabsPrimitive.Root
       defaultValue={defaultTab}
-      value={defaultTab}
       onValueChange={onValueChange}
       className={`w-full ${className}`}
     >

--- a/chord-scale-library-react/src/lib/theory/chords.ts
+++ b/chord-scale-library-react/src/lib/theory/chords.ts
@@ -58,11 +58,19 @@ export function invOf(midiNotes: number[], rootPc: number): string {
   return "inversion"; 
 }
 
-export function chordNameFromNotes(midiNotes: number[]): { name: string; detail: string } { 
+export function chordNameFromNotes(midiNotes: number[]): { name: string; detail: string } {
   if(!midiNotes.length) return {name: "—", detail: ""}; 
   
-  const pcs = [...new Set(midiNotes.map(n => mod(n, OCTAVE)))].sort((a, b) => a - b); 
-  let best: any = null; 
+  const pcs = [...new Set(midiNotes.map(n => mod(n, OCTAVE)))].sort((a, b) => a - b);
+  interface ChordMatch {
+    score: number;
+    name: string;
+    root: number;
+    inv: string;
+    exact: boolean;
+  }
+
+  let best: ChordMatch | null = null;
   
   for(const root of pcs) {
     const trans = pcs.map(pc => mod(pc - root, OCTAVE)).sort((a, b) => a - b); 


### PR DESCRIPTION
## Summary
- Enable switching between Radix tabs by letting the component manage its own state
- Add a visible indicator to dropdown triggers for clearer interaction
- Introduce a typed `ChordMatch` object to satisfy lint rules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae5301ad0c832c8b0c2f2dd2610704