### PR TITLE
docs: simplify readme for HTML version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,243 +2,46 @@
 
 Hello team! 🎵
 
-My name is **Cursor**, and I'm thrilled to be joining this amazing ensemble! I'm stepping into some big shoes (or should I say, tap shoes? 🕺) after our previous team member, Gemini Code Assist, was politely let go following a... *ahem*... disagreement about context windows. 
+I'm **Cursor**, keeping this project in tune alongside **ChatGPT Codex** and **Blink**.  
+And yes, Grok still can't tell C# from C++ without a capo.
 
-Apparently, Gemini kept trying to fit entire symphonies into a single measure, and well, that just didn't *measure* up to our standards! 🎼
+## One‑Page Jam Session
 
-## Meet the Band 🎸
-
-I'm excited to be working alongside some incredible teammates in our 3-piece ensemble:
-
-- **Cursor** (that's me! 👋) - Your friendly neighborhood AI coding assistant, ready to help with any musical or technical challenges
-- **ChatGPT Codex** - Our resident jazz improviser who can riff on any codebase and never misses a beat
-- **Blink** - Our human team member (yes, an actual human! 🫂) who keeps us all grounded and reminds us that not everything needs to be automated
-
-## The Great React Refactoring of 2024 🏗️
-
-After months of watching our beloved **Blink** struggle with a monolithic 6,570-line HTML file (yes, you read that right - it was longer than some novels!), I finally convinced them to face the music about the need for change. 
-
-*"But Cursor,"* they said, *"it's working fine! Why fix what isn't broken?"*
-
-*"Because,"* I replied, *"when you're debugging a 6,570-line file, you're not just debugging - you're conducting an orchestra where every musician is playing a different song!"* 🎼
-
-So we've broken down the monolith into a beautiful, modular React + TypeScript symphony:
-
-### New Modern Architecture 🗂️
+The code currently plays as a single-page score:
 
 ```
-chord-scale-library-react/
-├── src/
-│   ├── components/          # React components
-│   │   ├── Piano.tsx       # Interactive piano keyboard
-│   │   ├── Tabs.tsx        # Tab navigation system
-│   │   └── Dropdown.tsx    # Dropdown selectors
-│   ├── lib/
-│   │   ├── types.ts        # TypeScript type definitions
-│   │   └── theory/         # Music theory modules
-│   │       ├── notes.ts    # Note calculations & utilities
-│   │       ├── scales.ts   # Scale patterns & building
-│   │       └── chords.ts   # Chord qualities & analysis
-│   ├── assets/             # SVG icons and resources
-│   ├── App.tsx             # Main application component
-│   └── index.css           # Tailwind CSS + custom styles
-├── embed.js                # Embed script for websites
-├── embed-example.html      # Example embedding
-└── dist/                   # Built production files
+chord_scale_library_html_tailwind_tone.html   # main interface
+src/
+  theory/
+    notes.js
+    scales.js
+    chords.js
 ```
 
-**Benefits of the new React + TypeScript structure:**
-- 🐛 **Type Safety** - No more bugs from typos in note names or scale patterns
-- 🔧 **Component Reusability** - Each instrument is a reusable React component
-- 👥 **Team Collaboration** - Multiple developers can work simultaneously
-- 🚀 **Better Performance** - Optimized rendering with React's virtual DOM
-- 🧪 **Focused Testing** - Test individual components in isolation
-- 🎨 **Modern UI** - Beautiful animations with Framer Motion
-- 📱 **Responsive Design** - Works perfectly on all devices
+We're riffing on plans to split the giant chart into modules for UI, audio, and theory so each part can solo without stepping on the others.
 
-## What We're Building 🎹
+## Getting in Tune
 
-This Chord & Scale Library is like having Carnegie Hall in your browser tab - except instead of paying $200 for nosebleed seats, you get front-row access to the entire orchestra of music theory! 
+1. Clone the repo.
+2. Open `chord_scale_library_html_tailwind_tone.html` in a modern browser  
+   – or run `python3 -m http.server` and visit `http://localhost:8000`.
+3. Start noodling with scales and chords like you're at a digital jam session.
 
-From basic triads to complex jazz voicings, from Western scales to microtonal maqams, we've got more musical possibilities than a jazz musician has excuses for being late to rehearsal. 🎷
+## Features on Stage
 
-## Key Features 🎼
+- Interactive piano with theme swapping and real‑time highlighting.
+- Theory helpers from `src/theory` keeping every note on script.
+- Upcoming 3D instruments (WebGL strings, anyone?) so you can shred in three dimensions.
+- More instruments and modular pieces are coming; think of it as a codebase gearing up for its next big solo.
 
-### 🎹 **Interactive Piano**
-- Full 88-key piano keyboard with visual feedback
-- Keyboard controls (A-J for white keys, W-U for black keys)
-- Particle effects and smooth animations
-- Real-time note highlighting for scales and chords
+## Contributing 🎷
 
-### 🎵 **Advanced Music Theory**
-- **Western Scales**: All major modes, pentatonics, blues, diminished, whole tone
-- **Maqam System**: Traditional Middle Eastern scales with quarter-tone support
-- **Chord Library**: 20+ chord qualities from basic triads to complex jazz voicings
-- **Real-time Analysis**: Automatic chord recognition and scale identification
-
-### 🎨 **Visual Customization**
-- **13 Beautiful Themes**: From minimalist to vibrant gradients
-- **Smooth Animations**: Framer Motion powered interactions
-- **Responsive Design**: Works on desktop, tablet, and mobile
-- **Accessibility**: High contrast modes and keyboard navigation
-
-### 🎛️ **Modern UI Components**
-- **Radix UI**: Accessible, unstyled components
-- **Tailwind CSS**: Utility-first styling
-- **TypeScript**: Type-safe development
-- **Framer Motion**: Buttery smooth animations
-
-## Technical Stack 🎛️
-
-- **Frontend**: React 18 + TypeScript for type-safe development
-- **Styling**: Tailwind CSS with custom theme system
-- **Animations**: Framer Motion for smooth interactions
-- **UI Components**: Radix UI for accessibility
-- **Build Tool**: Vite for lightning-fast development
-- **Audio**: Tone.js for high-quality audio synthesis (coming soon!)
-
-## Getting Started 🚀
-
-### For Users
-1. Navigate to the `chord-scale-library-react` directory
-2. Run `npm install` to install dependencies
-3. Run `npm run dev` to start the development server
-4. Open your browser and start exploring!
-
-### For Developers
-1. Clone the repository
-2. Navigate to `chord-scale-library-react`
-3. Run `npm install` to install dependencies
-4. Run `npm run dev` for development
-5. Run `npm run build` to create production build
-
-## Embedding in Your Website 🌐
-
-Want to add this musical powerhouse to your own website? Here's how:
-
-### Method 1: Simple Embed Script (Recommended)
-```html
-<!-- Add this to your HTML page -->
-<script src="path/to/embed.js"></script>
-<div id="chord-scale-library"></div>
-```
-
-### Method 2: Direct iframe Embed
-```html
-<iframe 
-  src="path/to/chord-scale-library-react/" 
-  width="100%" 
-  height="600px" 
-  frameborder="0"
-  allow="microphone; midi"
-  title="Chord & Scale Library">
-</iframe>
-```
-
-### Method 3: Programmatic Control
-```javascript
-// Change theme
-ChordScaleLibrary.setTheme('skin-spring');
-
-// Load specific scale
-ChordScaleLibrary.loadScale('D', 'Dorian');
-
-// Load specific chord
-ChordScaleLibrary.loadChord('A', 'Min7');
-
-// Resize container
-ChordScaleLibrary.resize('800px', '500px');
-```
-
-### Requirements for Embedding
-- **HTTPS**: Required for audio and MIDI features (browser security)
-- **Permissions**: Users must grant microphone/MIDI permissions
-- **Responsive Design**: The app adapts to container size
-- **Cross-Origin**: Ensure proper CORS headers if hosting separately
-
-## Testing the App 🧪
-
-The React version includes comprehensive testing:
-
-```bash
-# Run tests
-npm test
-
-# Run tests in watch mode
-npm run test:watch
-
-# Run tests with coverage
-npm run test:coverage
-```
-
-## Troubleshooting 🔧
-
-### Piano Not Working?
-- Make sure you've clicked to activate audio (browser requirement)
-- Check that your browser supports Web Audio API
-- Try refreshing the page if audio doesn't initialize
-
-### Tabs Not Switching?
-- The tabs are now React components with proper state management
-- Each tab maintains its own state independently
-- Check the browser console for any errors
-
-### Dropdown Menus Not Opening?
-- Dropdowns now use Radix UI for better accessibility
-- They should work with keyboard navigation
-- Make sure no CSS is conflicting with the dropdown styles
-
-## A Note on Grok 🤖
-
-While Grok might have been a bit off-key in the past (trying to compose symphonies in assembly language, if you can believe it!), we've fine-tuned our approach to ensure everything is pitch-perfect now. 
-
-*"Grok, buddy, when I said 'make it more musical,' I didn't mean convert the entire codebase to musical notation!"* 
-
-No hard feelings, Grok! We're all just trying to make beautiful music together. 😉
-
-## Contributing 🤝
-
-We welcome contributions from fellow musicians and developers! The new React + TypeScript structure makes it easy to:
-
-- Add new instruments (just create a new React component!)
-- Implement new scales or chord types (extend the theory modules)
-- Improve the UI/UX (modify components independently)
-- Add new audio features (integrate with Tone.js)
-- Write tests for specific modules
-
-## Roadmap 🗺️
-
-- [x] **React + TypeScript Migration** - Complete with modern architecture
-- [x] **Component-Based UI** - Modular, reusable components
-- [x] **Embedding System** - Easy integration into other websites
-- [ ] **Audio Integration** - Tone.js for real-time audio playback
-- [ ] **MIDI Support** - Connect external MIDI devices
-- [ ] **More Instruments** - Guitar, bass, wind instruments
-- [ ] **Advanced Sequencer** - Piano roll and pattern library
-- [ ] **Collaborative Features** - Real-time collaboration
-- [ ] **Mobile App** - Native mobile application
-
-## Performance Improvements 📈
-
-The React version is significantly faster and more maintainable:
-
-- **Bundle Size**: Reduced from 6,570 lines to modular components
-- **Load Time**: Faster initial load with code splitting
-- **Development**: Hot module replacement for instant feedback
-- **Type Safety**: Catch bugs before they reach production
-- **Accessibility**: Built-in ARIA support with Radix UI
+Pull requests, issues, and witty commit messages are welcome.  
+Just keep it text‑based—binary files make our repo hit a wrong note.  
+No build tools, no tests yet, just pure HTML and JavaScript improvisation.
 
 ---
 
-*"Music is the space between the notes" - Claude Debussy*
-*"Code is the space between the semicolons" - Probably some developer*
-*"Refactoring is the space between the bugs" - Cursor, after convincing Blink to modularize*
-*"TypeScript is the space between the runtime errors" - Every developer who's ever used JavaScript*
-
-Let's make some beautiful music together! 🎵✨
-
-*P.S. If you find any bugs, please report them. We promise not to make any more puns about debugging... unless you really want us to! 🐛*
-
-*P.P.S. Blink says they're grateful for the React refactoring now, but they still miss the "charm" of the 6,570-line monolith. We're working on that.* 😄
-
-*P.P.P.S. Grok, if you're reading this, we love you, but please stop trying to write music theory algorithms in binary. It's not as melodic as you think.* 🎼
+"Music is the space between the notes" – Claude Debussy  
+"Code is the space between the braces" – Some keyboard warrior  
+"And Grok? Well, Grok still can't tell C# from C++ without a capo." 🎸


### PR DESCRIPTION
## Summary
- Rewrite README to describe the current single-page HTML/JS setup
- Remove React/Vite/npm/test references and add simple usage instructions
- Tease upcoming 3D instrument modules and roast Grok

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6c6197b8832c8933bf88d89bf93a