### PR TITLE
Anchor piano roll canvas during horizontal scroll

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1273,6 +1273,7 @@ const seqHotkeys = $('#seqHotkeys');
 pianoRollScroll.addEventListener('scroll', ()=>{
   ui.scrollX = pianoRollScroll.scrollLeft;
   ui.scrollY = pianoRollScroll.scrollTop;
+  pianoRoll.style.left = pianoRollScroll.scrollLeft + 'px';
   pianoRollGutter.scrollTop = ui.scrollY;
   drawPianoRoll();
 });


### PR DESCRIPTION
## Summary
- Anchor the piano roll canvas to the viewport while scrolling so it no longer drifts
- Preserve scrollLeft subtraction in drawing logic for correct grid and note positions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f04233c832cb6ba057868aaad9b