### PR TITLE
fix: smooth and throttle piano roll auto-scroll

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -2139,10 +2139,17 @@ pianoRoll.addEventListener('wheel', ev=>{
 
 let playheadReq=null;
 function startPlayhead(){
+  let skipScroll=false;
   function loop(){
     const cellW=20*ui.zoomX;
     const x=Tone.Transport.ticks/SIXTEENTH*cellW;
-    if(seqAutoScroll.checked){ pianoRollScroll.scrollLeft = x - pianoRollScroll.clientWidth/2; }
+    if(seqAutoScroll.checked){
+      const target = x - pianoRollScroll.clientWidth/2;
+      if(skipScroll){
+        pianoRollScroll.scrollLeft += (target - pianoRollScroll.scrollLeft) * 0.15;
+      }
+      skipScroll=!skipScroll;
+    }
     updatePositionDisplay();
     drawPianoRoll();
     playheadReq=requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- smooth playhead auto-scroll with interpolation
- throttle scroll updates to reduce jitter

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ae723f0ff0832cb4ece3cd1c38085f