### PR TITLE
feat: limit note sustain per instrument

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -513,18 +513,18 @@ function chordNameFromNotes(midiNotes){ if(!midiNotes.length) return {name:"—"
 
 // ========================= AUDIO (Tone.js) =========================
 let _synth=null; let _started=false; const ENV={
-  Piano:{a:.005,d:.3,s:.3,r:1.2,osc:'triangle',filter:{frequency:2500,Q:1}},
-  Guitar:{a:.005,d:.25,s:0,r:1.5,osc:'sawtooth',filter:{frequency:3000,Q:0.8},vibrato:{rate:6,depth:0.02}},
-  Bass:{a:.01,d:.3,s:.5,r:.9,osc:'square',filter:{frequency:800,Q:2}},
-  Violin:{a:.05,d:.2,s:.8,r:.8,osc:'sawtooth',vibrato:{rate:6.5,depth:0.08},filter:{frequency:4000,Q:1.2}},
-  Flute:{a:.06,d:.15,s:.85,r:.4,osc:'sine',vibrato:{rate:5,depth:0.05},filter:{frequency:5000,Q:0.5}},
-  Recorder:{a:.06,d:.12,s:.85,r:.4,osc:'sine',filter:{frequency:3500,Q:0.7}},
-  Trumpet:{a:.02,d:.25,s:.7,r:.6,osc:'square',filter:{frequency:3500,Q:1.5},vibrato:{rate:4,depth:0.03}},
-  Saxophone:{a:.03,d:.25,s:.7,r:.4,osc:'sawtooth',vibrato:{rate:5.5,depth:0.04},filter:{frequency:2800,Q:1.1}},
-  Koto:{a:.002,d:.3,s:0,r:1.6,osc:'triangle',filter:{frequency:4500,Q:0.8}},
-  Oud:{a:.002,d:.35,s:0,r:1.8,osc:'triangle',filter:{frequency:3800,Q:0.9}},
-  Ney:{a:.12,d:.2,s:.8,r:.6,osc:'sine',vibrato:{rate:4.5,depth:0.06},filter:{frequency:2200,Q:0.6}},
-  'Hammond Organ':{a:.01,d:.3,s:.9,r:.8,osc:'square',filter:{frequency:5000,Q:0.3},tremolo:{rate:6,depth:0.3}},
+  Piano:{a:.005,d:.3,s:.3,r:1.2,osc:'triangle',filter:{frequency:2500,Q:1},maxSustain:4},
+  Guitar:{a:.005,d:.25,s:.3,r:1.5,osc:'sawtooth',filter:{frequency:3000,Q:0.8},vibrato:{rate:6,depth:0.02},maxSustain:3},
+  Bass:{a:.01,d:.3,s:.5,r:.9,osc:'square',filter:{frequency:800,Q:2},maxSustain:3},
+  Violin:{a:.05,d:.2,s:.8,r:.8,osc:'sawtooth',vibrato:{rate:6.5,depth:0.08},filter:{frequency:4000,Q:1.2},maxSustain:5},
+  Flute:{a:.06,d:.15,s:.85,r:.4,osc:'sine',vibrato:{rate:5,depth:0.05},filter:{frequency:5000,Q:0.5},maxSustain:4},
+  Recorder:{a:.06,d:.12,s:.85,r:.4,osc:'sine',filter:{frequency:3500,Q:0.7},maxSustain:3},
+  Trumpet:{a:.02,d:.25,s:.7,r:.6,osc:'square',filter:{frequency:3500,Q:1.5},vibrato:{rate:4,depth:0.03},maxSustain:3},
+  Saxophone:{a:.03,d:.25,s:.7,r:.4,osc:'sawtooth',vibrato:{rate:5.5,depth:0.04},filter:{frequency:2800,Q:1.1},maxSustain:4},
+  Koto:{a:.002,d:.3,s:0,r:1.6,osc:'triangle',filter:{frequency:4500,Q:0.8},maxSustain:3},
+  Oud:{a:.002,d:.35,s:0,r:1.8,osc:'triangle',filter:{frequency:3800,Q:0.9},maxSustain:3},
+  Ney:{a:.12,d:.2,s:.8,r:.6,osc:'sine',vibrato:{rate:4.5,depth:0.06},filter:{frequency:2200,Q:0.6},maxSustain:4},
+  'Hammond Organ':{a:.01,d:.3,s:.9,r:.8,osc:'square',filter:{frequency:5000,Q:0.3},tremolo:{rate:6,depth:0.3},maxSustain:6},
 };
 
 const masterLim = new Tone.Limiter(-1).toDestination();
@@ -1575,6 +1575,8 @@ function scheduleAhead(){
   song.tracks.forEach(track => {
     const active = anySolo ? track.solo : !track.mute;
     if(!active || !track.player) return;
+    const env = ENV[track.instrument] || ENV.Piano;
+    const maxDurTicks = env.maxSustain * song.ppq * 4;
     track.clips.forEach(clip => {
       clip.notes.forEach(n => {
         let when = clip.start + n.tick;
@@ -1583,7 +1585,8 @@ function scheduleAhead(){
         }
         if(when >= scheduledUntil && when < endTick){
           Tone.Transport.schedule(time => {
-            track.player.trigger(n.midi, time, n.vel ?? 0.8, `${n.dur}i`);
+            const dur = Math.min(n.dur, maxDurTicks);
+            track.player.trigger(n.midi, time, n.vel ?? 0.8, `${dur}i`);
           }, `${when}i`);
         }
       });


### PR DESCRIPTION
## Summary
- add `maxSustain` envelope limits for all instruments and raise guitar sustain
- clamp scheduled note duration to an instrument's natural sustain

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7563f838832ca69aaa2bfe71a4ff