### PR TITLE
Convert MetalSynth note to frequency

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1159,7 +1159,7 @@ function makeMetal(opts){
   const synth = new Tone.MetalSynth(opts).connect(gain);
   return {
     trigger(note, time=Tone.now(), velocity=1, duration='8n'){
-      synth.triggerAttackRelease(duration, time, velocity);
+      synth.triggerAttackRelease(midiToFreq(note), duration, time, velocity);
     },
     setVolume(v){ gain.gain.value = v; },
     setPan(p){ panner.pan.value = Math.max(-1, Math.min(1, p)); },


### PR DESCRIPTION
## Summary
- Convert MIDI note to frequency in `makeMetal.trigger`
- Pass duration, time, and velocity to `triggerAttackRelease`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae80edfcf4832cb0326cd79e77da03