### PR TITLE
Use supported guitar sample name

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -604,7 +604,7 @@ function makeSynth(type, env, options = {}) {
 
 // ========================= SAMPLE-BASED INSTRUMENTS =========================
 let sampleLibrary = null;
-const SAMPLED_INSTRUMENTS = ['piano', 'saxophone', 'trumpet', 'violin', 'guitar', 'flute'];
+const SAMPLED_INSTRUMENTS = ['piano', 'saxophone', 'trumpet', 'violin', 'guitar-acoustic', 'flute'];
 
 function makeSampler(instrumentName) {
   if (!sampleLibrary || !sampleLibrary[instrumentName]) {
@@ -667,7 +667,7 @@ async function initSampleLibrary() {
 
 const SEQ_INSTR = {
   Piano: () => makeSampler('piano') || makeSynth('PolySynth', ENV.Piano),
-  Guitar: () => makeSampler('guitar') || makeSynth('PluckSynth', ENV.Guitar, { pluckOptions: { attackNoise: 0.5, dampening: 1800, resonance: 0.8 } }),
+  Guitar: () => makeSampler('guitar-acoustic') || makeSynth('PluckSynth', ENV.Guitar, { pluckOptions: { attackNoise: 0.5, dampening: 1800, resonance: 0.8 } }),
   Bass: () => makeSynth('MonoSynth', ENV.Bass),
   Violin: () => makeSampler('violin') || makeSynth('PolySynth', ENV.Violin, { vibrato: true }),
   Flute: () => makeSampler('flute') || makeSynth('PolySynth', ENV.Flute, { vibrato: true }),


### PR DESCRIPTION
## Summary
- Use `guitar-acoustic` in sampled instrument list so the library fetches the correct guitar samples
- Load the acoustic guitar sampler before falling back to synthesis in sequence instrument factory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81f99c58832c82ffe12611ea2372