### PR TITLE
Visualize sustain gap on piano roll notes

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1743,6 +1743,7 @@ function exportSongMidi(){
 }
 
 function hexToRgba(hex,a){ const r=parseInt(hex.slice(1,3),16),g=parseInt(hex.slice(3,5),16),b=parseInt(hex.slice(5,7),16); return `rgba(${r},${g},${b},${a})`; }
+function lightenColor(hex,amt){ const r=parseInt(hex.slice(1,3),16),g=parseInt(hex.slice(3,5),16),b=parseInt(hex.slice(5,7),16); const lr=Math.min(255,Math.round(r+(255-r)*amt)),lg=Math.min(255,Math.round(g+(255-g)*amt)),lb=Math.min(255,Math.round(b+(255-b)*amt)); return `#${lr.toString(16).padStart(2,'0')}${lg.toString(16).padStart(2,'0')}${lb.toString(16).padStart(2,'0')}`; }
 function drawPianoRoll(){
   const clip = song.tracks[activeTrack].clips[0];
   // Auto-extend clip length if needed based on actual notes - generous buffer for large files
@@ -1807,7 +1808,9 @@ function drawPianoRoll(){
   const bottomMidi = MAX_MIDI - Math.ceil((pianoRollScroll.scrollTop + pianoRollScroll.clientHeight) / cellH);
   
   song.tracks.forEach((track,idx)=>{
-    const baseColor = hexToRgba(track.color||'#60a5fa', idx===activeTrack?1:0.3);
+    const alpha=idx===activeTrack?1:0.4;
+    const baseColor=hexToRgba(track.color||'#60a5fa',alpha);
+    const sustainColor=hexToRgba(lightenColor(track.color||'#60a5fa',0.5),alpha);
     // Pre-filter notes for viewport culling - major performance improvement for large files
     const visibleNotes = track.clips[0].notes.filter(n =>
       n.tick + n.dur >= startTick && n.tick <= endTick &&
@@ -1825,9 +1828,11 @@ function drawPianoRoll(){
         ctx.fillRect(x-2, y-2, w+4, cellH+4);
       }
 
-      // Draw note using track color
-      ctx.fillStyle = baseColor;
-      ctx.fillRect(x,y,w,cellH);
+      const sustainWidth=Math.min(8,w*0.15);
+      ctx.fillStyle=sustainColor;
+      ctx.fillRect(x,y,sustainWidth,cellH);
+      ctx.fillStyle=baseColor;
+      ctx.fillRect(x+sustainWidth,y,w-sustainWidth,cellH);
 
       // Add subtle border for clarity
       ctx.strokeStyle = 'rgba(0,0,0,0.4)';


### PR DESCRIPTION
## Summary
- Add `lightenColor` helper and render notes with a leading sustain gap
- Shade the sustain gap with a lighter track color and ghost inactive tracks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae832fe2cc832c85cbaaf9499576ea