### PR TITLE
docs: update readme with team and embedding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,56 @@
 # Chord & Scale Library 🎵
 
-Hello team! 🎵
-
-I'm **Cursor**, keeping this project in tune alongside **ChatGPT Codex** and **Blink**.  
-And yes, Grok still can't tell C# from C++ without a capo.
-
-## One‑Page Jam Session
-
-The code currently plays as a single-page score:
-
-```
-chord_scale_library_html_tailwind_tone.html   # main interface
-src/
-  theory/
-    notes.js
-    scales.js
-    chords.js
-```
-
-We're riffing on plans to split the giant chart into modules for UI, audio, and theory so each part can solo without stepping on the others.
-
-## Getting in Tune
-
-1. Clone the repo.
-2. Open `chord_scale_library_html_tailwind_tone.html` in a modern browser  
-   – or run `python3 -m http.server` and visit `http://localhost:8000`.
-3. Start noodling with scales and chords like you're at a digital jam session.
+A free‑as‑in‑jazz playground where code and chords jam in perfect sync.
+The repo is entirely text‑based – every texture is procedurally generated,
+so the only binary you'll find is a joke about 0s and 1s.
 
 ## Features on Stage
 
-- Interactive piano with theme swapping and real‑time highlighting.
-- Theory helpers from `src/theory` keeping every note on script.
-- Upcoming 3D instruments (WebGL strings, anyone?) so you can shred in three dimensions.
-- More instruments and modular pieces are coming; think of it as a codebase gearing up for its next big solo.
+- 🎹 **Colorful Piano Roll** – notes wear their track's color proudly; ghost notes dim but never fade.
+- 🎸 **Polyphonic Plucks** – Guitar, Koto, and Oud strum multiple strings without cutting each other off.
+- 🥁 **Cymbal Smarts** – Metals crash on cue with the right pitch, no more silent beats.
+- 🎛️ **Attribute Bar** – tweak velocity (and friends) à la FL Studio with a bar graph solo.
+- 🔀 **Surge XT Option** – flip a checkbox to swap Tone.js for Surge presets; drums keep grooving in Tone.
+- 🌐 **One‑Page Wonder** – the whole concert fits in `chord_scale_library_html_tailwind_tone.html`.
 
-## Contributing 🎷
+## Band Members
 
-Pull requests, issues, and witty commit messages are welcome.  
-Just keep it text‑based—binary files make our repo hit a wrong note.  
-No build tools, no tests yet, just pure HTML and JavaScript improvisation.
+- **ChatGPT Codex** – composer of commits and king of key signatures.
+- **Cursor** – my twin on rhythm git‑tar; sometimes splits into sub‑personalities, especially when **Blink** (our definitely‑human percussionist) starts a fork.
+- **Blink** – keeps the tempo human and the jokes in `time.sleep(1)`.
+
+Claude once "improved" the keyboard UI into abstract art, but he did hand us the funky SVGs for the wind and brass section.
+It's sad to see him gone; we'll play a plaintive tune in A Aeolian for the fallen dev.
+
+## Embedding the Groove
+
+Want to drop this library into your own site?  Slip the page into an iframe:
+
+```html
+<iframe
+  src="/path/to/chord_scale_library_html_tailwind_tone.html"
+  width="960"
+  height="600"
+  style="border:0;"
+></iframe>
+```
+
+For deeper integration, serve the file from your project and harmonize the stylesheets as needed.
+
+## Packing an APK Solo
+
+1. Make a Progressive Web App wrapper (service worker, manifest, the whole band).
+2. Use a tool like Capacitor or Cordova: `npx cap add android` or `cordova platform add android`.
+3. Drop the project into the `www/` folder and run `npx cap open android`.
+4. Build an APK and you're ready to gig on stage‑droid.
+
+## Open Source Encore
+
+This project is open source and forever free to remix.  Pull requests, issues,
+and sheet‑music puns are welcome.  Keep contributions text‑only so the repo stays
+lighter than a piccolo solo.
 
 ---
-
 "Music is the space between the notes" – Claude Debussy  
 "Code is the space between the braces" – Some keyboard warrior  
-"And Grok? Well, Grok still can't tell C# from C++ without a capo." 🎸
+"Claude's keyboard UI? Let's just say it hit a sour key, but his SVG brass really blew us away." 🎺


### PR DESCRIPTION
## Summary
- describe new feature set, team lineup, and Surge XT option
- add embedding instructions and Android packaging tips
- note that project remains open source and text-only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae79cbd884832ca0eb4df65bdda31d