### PR TITLE
feat: refine grid for varied time signatures

### DIFF
--- a/chord_scale_library_html_tailwind_tone.html
+++ b/chord_scale_library_html_tailwind_tone.html
@@ -1877,8 +1877,14 @@ function drawPianoRoll(){
   // background lanes
   for(let i=0;i<noteCount;i++){ ctx.fillStyle = i%2? '#243341':'#23303c'; ctx.fillRect(0,i*cellH,width,cellH); }
   // grid vertical
+  const stepsPerBeat = 16 / song.ts.den;
+  const stepsPerMeasure = song.ts.num * stepsPerBeat;
   for(let i=startStep;i<=endStep;i++){
-    const x=i*cellW - scrollLeft; ctx.strokeStyle='#2d3c4a'; if(i%(song.ppq/ SIXTEENTH)===0) ctx.strokeStyle='#395063'; if(i%(song.ts.num*song.ppq/SIXTEENTH)===0) ctx.strokeStyle='#4a6379'; ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,height); ctx.stroke();
+    const x = i*cellW - scrollLeft;
+    ctx.strokeStyle = '#2d3c4a';
+    if(i % stepsPerBeat === 0) ctx.strokeStyle = '#395063';
+    if(i % stepsPerMeasure === 0) ctx.strokeStyle = '#4a6379';
+    ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,height); ctx.stroke();
   }
   // horizontal lines
   for(let j=0;j<=noteCount;j++){ const y=j*cellH; ctx.strokeStyle='#2d3c4a'; ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(width,y); ctx.stroke(); }


### PR DESCRIPTION
## Summary
- compute sequencer grid spacing based on time-signature denominator and numerator
- style beat and measure lines using modular arithmetic for accurate bar alignment

## Testing
- `node -e "function test(ts){const stepsPerBeat=16/ts.den; const stepsPerMeasure=ts.num*stepsPerBeat; let marks=[]; for(let i=0;i<=stepsPerMeasure*2;i++){ let mark=''; if(i % stepsPerBeat===0) mark+='B'; if(i % stepsPerMeasure===0) mark+='M'; marks.push(i+':'+mark); } console.log(ts.num+'/'+ts.den, 'stepsPerBeat',stepsPerBeat,'stepsPerMeasure',stepsPerMeasure); console.log(marks.join(' '));}; [ {num:4,den:4}, {num:6,den:8}, {num:5,den:16} ].forEach(test);"`

------
https://chatgpt.com/codex/tasks/task_e_68ae8ce7b0a0832cb26b627fc7f59a71