### PR TITLE
Add basic theory tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "chord-and-keys",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests"
+  }
+}

--- a/tests/chords.test.js
+++ b/tests/chords.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildChord, chordToMidi } from '../src/theory/chords.js';
+
+test('buildChord forms minor triad', () => {
+  assert.deepStrictEqual(buildChord('C', 'Min'), ['C', 'D#', 'G']);
+});
+
+test('buildChord defaults to major for unknown quality', () => {
+  assert.deepStrictEqual(buildChord('C', 'Crazy'), ['C', 'E', 'G']);
+});
+
+test('buildChord returns empty array for invalid root', () => {
+  assert.deepStrictEqual(buildChord('H', 'Min'), []);
+});
+
+test('chordToMidi converts notes to midi numbers', async () => {
+  const midi = await chordToMidi(['C', 'E', 'G'], 'C', 4);
+  assert.deepStrictEqual(midi, [55, 60, 64]);
+});
+
+test('chordToMidi returns empty array for invalid root', async () => {
+  const midi = await chordToMidi(['C', 'E', 'G'], 'H', 4);
+  assert.deepStrictEqual(midi, []);
+});

--- a/tests/notes.test.js
+++ b/tests/notes.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pcIndex, pcName, midiFrom } from '../src/theory/notes.js';
+
+test('pcIndex handles quarter-tones', () => {
+  assert.strictEqual(pcIndex('C+'), 0.5);
+});
+
+test('pcIndex returns null for invalid note', () => {
+  assert.strictEqual(pcIndex('H'), null);
+});
+
+test('pcName wraps negative values', () => {
+  assert.strictEqual(pcName(-1), 'B');
+});
+
+test('midiFrom returns expected value', () => {
+  assert.strictEqual(midiFrom('A', 4), 69);
+});
+
+test('midiFrom returns null for invalid note', () => {
+  assert.strictEqual(midiFrom('H'), null);
+});

--- a/tests/scales.test.js
+++ b/tests/scales.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildScale, scaleToMidi } from '../src/theory/scales.js';
+
+test('buildScale generates Dorian mode', () => {
+  assert.deepStrictEqual(buildScale('C', 'Dorian'), ['C', 'D', 'D#', 'F', 'G', 'A', 'A#']);
+});
+
+test('buildScale handles quarter-tone maqam', () => {
+  assert.deepStrictEqual(buildScale('C', 'Maqam Rast'), ['C', 'D', 'D#+', 'F', 'G', 'A', 'A#+']);
+});
+
+test('buildScale returns empty array for invalid tonic', () => {
+  assert.deepStrictEqual(buildScale('H', 'Ionian'), []);
+});
+
+test('scaleToMidi converts scale to midi numbers', async () => {
+  const notes = buildScale('C', 'Ionian');
+  const midi = await scaleToMidi(notes, 'C', 4);
+  assert.deepStrictEqual(midi.slice(0, 4), [60, 62, 64, 65]);
+});


### PR DESCRIPTION
## Summary
- add node:test suite for chords, notes, and scales utilities
- include package.json with `npm test` script
- verify interval math and edge cases across modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d8d6dec832cacbbb81e26e96cfe